### PR TITLE
Deploy docs on 3.13

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -42,12 +42,16 @@ jobs:
           fi
         env:
           DOCS_DEV: false
+          # TODO: Remove once maturin supports 3.14
+          UV_PYTHON: "3.13"
 
       - name: Deploy dev docs
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: uv run mike deploy --push --update-aliases dev
         env:
           DOCS_DEV: true
+          # TODO: Remove once maturin supports 3.14
+          UV_PYTHON: "3.13"
 
       # - name: Update default release docs
       #   run: mike set-default --push latest


### PR DESCRIPTION
For whatever reason building the docs requires maturin for the dependencies, which does not work with Python 3.14. This fixes the build for now.