### PR TITLE
Image casting, downsampling, and pygfx texture reuse

### DIFF
--- a/src/scenex/adaptors/_pygfx/_image.py
+++ b/src/scenex/adaptors/_pygfx/_image.py
@@ -19,12 +19,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("scenex.adaptors.pygfx")
 
-# Certain numpy data types are not supported by pygfx. We downcast them to another type
-# defined in this dict.
-DOWNCASTS = {
+# Certain numpy data types are not supported by pygfx. We downthem to another type
+# defined in this dict. Given the options of downcasting to uint16 (causing
+# clipping/wrap around) or float32 (which can represent the full range of int32/64) we
+# choose the latter. We may lose some precision for large integers, but this is likely
+# less bad than downcasting
+CASTS = {
     np.dtype("float64"): np.dtype("float32"),
-    np.dtype("int64"): np.dtype("int32"),
-    np.dtype("uint64"): np.dtype("uint32"),
+    np.dtype("int64"): np.dtype("float32"),
+    np.dtype("uint64"): np.dtype("float32"),
 }
 
 
@@ -171,10 +174,10 @@ def _coerce_data(data: np.ndarray, n_spatial: Literal[2, 3]) -> np.ndarray:
     Returns a (possibly strided) view — callers that need to own the
     buffer must ``.copy()`` it.
     """
-    if data.dtype in DOWNCASTS:
-        cast_to = DOWNCASTS[data.dtype]
+    if data.dtype in CASTS:
+        cast_to = CASTS[data.dtype]
         logger.warning(
-            "Downcasting %s data from %s to %s for pygfx compatibility",
+            "Casting %s data from %s to %s for pygfx compatibility",
             "image" if n_spatial == 2 else "volume",
             data.dtype.name,
             cast_to.name,

--- a/src/scenex/adaptors/_pygfx/_image.py
+++ b/src/scenex/adaptors/_pygfx/_image.py
@@ -68,21 +68,25 @@ class Image(Node, ImageAdaptor):
     def _snx_set_transform(self, arg: model.Transform) -> None:
         if not hasattr(self, "_pygfx_node"):
             return  # _snx_set_data hasn't run yet to set initial factors
-        x_fac = self._model.data.shape[0] / self._texture.size[1]
-        y_fac = self._model.data.shape[1] / self._texture.size[0]
+        # Compensate for downscaled textures
+        # NOTE that image axes are YX in model space
+        # but the pygfx Texture shape will be (X, Y, 1).
+        y_fac = self._model.data.shape[0] / self._texture.size[1]
+        x_fac = self._model.data.shape[1] / self._texture.size[0]
         self._pygfx_node.local.matrix = (
-            arg.scaled((y_fac, x_fac, 1))
-            .translated((0.5 * (y_fac - 1), 0.5 * (x_fac - 1), 0))
+            arg.scaled((x_fac, y_fac, 1))
+            .translated((0.5 * (x_fac - 1), 0.5 * (y_fac - 1), 0))
             .root.T
         )
 
     def _snx_set_data(self, data: ArrayLike) -> None:
-        arr = np.asanyarray(data)
-        processed = _coerce_data(arr, n_spatial=2)
+        # Coerce the data to something that can be displayed by pygfx
+        processed = _coerce_data(np.asanyarray(data), n_spatial=2)
 
+        # If we have a texture already, see whether we can reuse it:
         current: pygfx.Texture | None = getattr(self, "_texture", None)
         if current is not None and _can_reuse(current, processed):
-            # Reuse the existing texture: overwrite its buffer and mark dirty.
+            # To reuse, we overwrite its buffer and mark dirty.
             current.data[:] = processed  # pyright: ignore
             current.update_full()
         else:
@@ -98,9 +102,9 @@ class Image(Node, ImageAdaptor):
                 if current is not None and current.data is not None
                 else None
             )
-            if prev_ndim != arr.ndim:
+            if prev_ndim != processed.ndim:
                 self._material.map = (
-                    None if arr.ndim == 3 else self._model.cmap.to_pygfx()
+                    None if processed.ndim == 3 else self._model.cmap.to_pygfx()
                 )
 
         # Keep transform compensation in sync whenever data or factors change.
@@ -109,7 +113,11 @@ class Image(Node, ImageAdaptor):
 
 def _texture_dim(data: np.ndarray) -> int:
     """Spatial dimensionality of *image data* for a pygfx Texture."""
-    return data.ndim - 1 if data.ndim > 2 and data.shape[-1] <= 4 else data.ndim
+    if data.ndim > 2 and data.shape[-1] in (3, 4):
+        # RGB or RGBA image - treat as 2D with a channel dimension, not 3D
+        return 2
+    # Otherwise the number of spatial dimensions is just the number of dimensions
+    return data.ndim
 
 
 @lru_cache(maxsize=1)
@@ -120,8 +128,9 @@ def _get_max_texture_sizes() -> tuple[int | None, int | None]:
 
         adapter = wgpu.gpu.request_adapter_sync()
         limits = adapter.limits
-        return limits.get("max-texture-dimension-2d"), limits.get(
-            "max-texture-dimension-3d"
+        return (
+            limits.get("max-texture-dimension-2d"),
+            limits.get("max-texture-dimension-3d"),
         )
     except Exception:
         return None, None

--- a/src/scenex/adaptors/_pygfx/_image.py
+++ b/src/scenex/adaptors/_pygfx/_image.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -41,8 +42,8 @@ class Image(Node, ImageAdaptor):
             # This value has model render order win for coplanar objects
             depth_compare="<=",
         )
+        self._pygfx_node = pygfx.Image(material=self._material)
         self._snx_set_data(image.data)
-        self._pygfx_node = pygfx.Image(self._geometry, self._material)
 
     def _snx_set_cmap(self, arg: Colormap) -> None:
         if np.asarray(self._model.data).ndim == 3:
@@ -65,33 +66,125 @@ class Image(Node, ImageAdaptor):
             return
         self._material.interpolation = arg
 
-    def _create_texture(self, data: ArrayLike | None) -> pygfx.Texture:
-        if data is not None:
-            data = np.asanyarray(data)
-            dim = data.ndim
-            if dim > 2 and data.shape[-1] <= 4:
-                dim -= 1  # last array dim is probably (a subset of) rgba
-            if data.dtype in DOWNCASTS:
-                cast_to = DOWNCASTS[data.dtype]
-                # pygfx doesn't support 64-bit dtypes; downcast transparently.
-                # The user hasn't done anything wrong — this is a backend limitation.
-                logger.warning(
-                    "Downcasting image data from %s to %s for pygfx compatibility",
-                    data.dtype.name,
-                    cast_to.name,
-                )
-                data = data.astype(cast_to)
-        else:
-            dim = 2
-        # TODO: unclear whether get_view() is better here...
-        return pygfx.Texture(data, dim=dim)
+    def _snx_set_transform(self, arg: model.Transform) -> None:
+        if not hasattr(self, "_pygfx_node"):
+            return  # _snx_set_data hasn't run yet to set initial factors
+        x_fac = self._model.data.shape[0] / self._texture.size[1]
+        y_fac = self._model.data.shape[1] / self._texture.size[0]
+        self._pygfx_node.local.matrix = (
+            arg.scaled((y_fac, x_fac, 1))
+            .translated((0.5 * (y_fac - 1), 0.5 * (x_fac - 1), 0))
+            .root.T
+        )
 
     def _snx_set_data(self, data: ArrayLike) -> None:
-        self._texture = self._create_texture(data)
-        self._geometry = pygfx.Geometry(grid=self._texture)
-        if hasattr(self, "_pygfx_node"):
-            self._pygfx_node.geometry = self._geometry
-        if np.asarray(data).ndim == 3:
-            self._material.map = None
+        arr = np.asanyarray(data)
+        processed = _coerce_data(arr)
+
+        current: pygfx.Texture | None = getattr(self, "_texture", None)
+        if current is not None and _can_reuse(current, processed):
+            # Reuse the existing texture: overwrite its buffer and mark dirty.
+            current.data[:] = processed  # pyright: ignore
+            current.update_full()
         else:
-            self._material.map = self._model.cmap.to_pygfx()
+            # Copy so later in-place reuse won't mutate the originally-passed array.
+            new_buffer = processed.copy()
+            self._texture = pygfx.Texture(new_buffer, dim=_texture_dim(processed))
+            self._pygfx_node.geometry = pygfx.Geometry(grid=self._texture)
+            # Only update the material map when the array dimensionality changes
+            # (grayscale ↔ RGB/RGBA) or on first creation; otherwise the existing
+            # map is still correct and recreating it is wasteful.
+            prev_ndim = (
+                current.data.ndim
+                if current is not None and current.data is not None
+                else None
+            )
+            if prev_ndim != arr.ndim:
+                self._material.map = (
+                    None if arr.ndim == 3 else self._model.cmap.to_pygfx()
+                )
+
+        # Keep transform compensation in sync whenever data or factors change.
+        self._snx_set_transform(self._model.transform)
+
+
+def _texture_dim(data: np.ndarray) -> int:
+    """Spatial dimensionality of *data* for a pygfx Texture."""
+    return data.ndim - 1 if data.ndim > 2 and data.shape[-1] <= 4 else data.ndim
+
+
+@lru_cache(maxsize=1)
+def _get_max_texture_sizes() -> tuple[int | None, int | None]:
+    """Return (max_2d, max_3d) texture dimensions from the wgpu adapter."""
+    try:
+        import wgpu
+
+        adapter = wgpu.gpu.request_adapter_sync()
+        limits = adapter.limits
+        return limits.get("max-texture-dimension-2d"), limits.get(
+            "max-texture-dimension-3d"
+        )
+    except Exception:
+        return None, None
+
+
+def _downsample_data(data: np.ndarray, max_size: int) -> np.ndarray:
+    """Downsample spatial axes of *data* so none exceeds *max_size*.
+
+    Uses a strided NumPy view (no copy). For 2-D arrays the shape is
+    ``(rows, cols)``; for 3-D arrays with a trailing colour channel
+    (shape[-1] <= 4) only the two spatial axes are checked.
+
+    Returns the (possibly downsampled) array.
+    """
+    has_channel = data.ndim == 3 and data.shape[-1] <= 4
+    spatial_shape = data.shape[:-1] if has_channel else data.shape
+    row_f, col_f = (
+        int(np.ceil(s / max_size)) if s > max_size else 1 for s in spatial_shape
+    )
+    if row_f == 1 and col_f == 1:
+        return data
+    logger.warning(
+        "Data shape %s exceeds max texture dimension (%d) and will be "
+        "downsampled for rendering (strides: (%d, %d)).",
+        data.shape,
+        max_size,
+        row_f,
+        col_f,
+    )
+    slices: tuple[slice, ...] = (slice(None, None, row_f), slice(None, None, col_f))
+    if has_channel:
+        slices = (*slices, slice(None))
+    return data[slices]
+
+
+def _coerce_data(data: np.ndarray) -> np.ndarray:
+    """Downcast and downsample *data* for GPU upload.
+
+    Returns a (possibly strided) view — callers that need to own the
+    buffer must ``.copy()`` it.
+    """
+    if data.dtype in DOWNCASTS:
+        cast_to = DOWNCASTS[data.dtype]
+        logger.warning(
+            "Downcasting image data from %s to %s for pygfx compatibility",
+            data.dtype.name,
+            cast_to.name,
+        )
+        data = data.astype(cast_to)  # astype always returns a copy
+
+    max_size = _get_max_texture_sizes()[0]
+    if max_size is not None:
+        data = _downsample_data(data, max_size)
+
+    return data
+
+
+def _can_reuse(texture: pygfx.Texture, processed: np.ndarray) -> bool:
+    """True if *texture* can hold *processed* without reallocation."""
+    return (
+        texture.data is not None
+        and texture.data.shape == processed.shape
+        and texture.data.dtype == processed.dtype
+        and texture.dim == _texture_dim(processed)
+    )

--- a/src/scenex/adaptors/_pygfx/_image.py
+++ b/src/scenex/adaptors/_pygfx/_image.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pygfx
@@ -33,7 +33,6 @@ class Image(Node, ImageAdaptor):
 
     _pygfx_node: pygfx.Image
     _material: pygfx.ImageBasicMaterial
-    _geometry: pygfx.Geometry
 
     def __init__(self, image: model.Image, **backend_kwargs: Any) -> None:
         self._model = image
@@ -79,7 +78,7 @@ class Image(Node, ImageAdaptor):
 
     def _snx_set_data(self, data: ArrayLike) -> None:
         arr = np.asanyarray(data)
-        processed = _coerce_data(arr)
+        processed = _coerce_data(arr, n_spatial=2)
 
         current: pygfx.Texture | None = getattr(self, "_texture", None)
         if current is not None and _can_reuse(current, processed):
@@ -109,7 +108,7 @@ class Image(Node, ImageAdaptor):
 
 
 def _texture_dim(data: np.ndarray) -> int:
-    """Spatial dimensionality of *data* for a pygfx Texture."""
+    """Spatial dimensionality of *image data* for a pygfx Texture."""
     return data.ndim - 1 if data.ndim > 2 and data.shape[-1] <= 4 else data.ndim
 
 
@@ -128,37 +127,36 @@ def _get_max_texture_sizes() -> tuple[int | None, int | None]:
         return None, None
 
 
-def _downsample_data(data: np.ndarray, max_size: int) -> np.ndarray:
-    """Downsample spatial axes of *data* so none exceeds *max_size*.
+def _downsample_data(data: np.ndarray, max_size: int, n_spatial: int) -> np.ndarray:
+    """Downsample the spatial axes of *data* so none exceeds *max_size*.
 
-    Uses a strided NumPy view (no copy). For 2-D arrays the shape is
-    ``(rows, cols)``; for 3-D arrays with a trailing colour channel
-    (shape[-1] <= 4) only the two spatial axes are checked.
+    Uses a strided NumPy view (no copy). Any trailing non-spatial axis (e.g. a
+    colour channel) is left untouched.
 
     Returns the (possibly downsampled) array.
     """
-    has_channel = data.ndim == 3 and data.shape[-1] <= 4
-    spatial_shape = data.shape[:-1] if has_channel else data.shape
-    row_f, col_f = (
-        int(np.ceil(s / max_size)) if s > max_size else 1 for s in spatial_shape
+    # If the data has more than n_spatial axes, assume the last one is a channel (RGBA).
+    has_channel = data.ndim > n_spatial
+    strides = tuple(
+        int(np.ceil(s / max_size)) if s > max_size else 1
+        for s in data.shape[:n_spatial]
     )
-    if row_f == 1 and col_f == 1:
+    if all(s == 1 for s in strides):
         return data
     logger.warning(
         "Data shape %s exceeds max texture dimension (%d) and will be "
-        "downsampled for rendering (strides: (%d, %d)).",
+        "downsampled for rendering (strides: %s).",
         data.shape,
         max_size,
-        row_f,
-        col_f,
+        strides,
     )
-    slices: tuple[slice, ...] = (slice(None, None, row_f), slice(None, None, col_f))
+    slices: tuple[slice, ...] = tuple(slice(None, None, s) for s in strides)
     if has_channel:
         slices = (*slices, slice(None))
     return data[slices]
 
 
-def _coerce_data(data: np.ndarray) -> np.ndarray:
+def _coerce_data(data: np.ndarray, n_spatial: Literal[2, 3]) -> np.ndarray:
     """Downcast and downsample *data* for GPU upload.
 
     Returns a (possibly strided) view — callers that need to own the
@@ -167,15 +165,16 @@ def _coerce_data(data: np.ndarray) -> np.ndarray:
     if data.dtype in DOWNCASTS:
         cast_to = DOWNCASTS[data.dtype]
         logger.warning(
-            "Downcasting image data from %s to %s for pygfx compatibility",
+            "Downcasting %s data from %s to %s for pygfx compatibility",
+            "image" if n_spatial == 2 else "volume",
             data.dtype.name,
             cast_to.name,
         )
         data = data.astype(cast_to)  # astype always returns a copy
 
-    max_size = _get_max_texture_sizes()[0]
+    max_size = _get_max_texture_sizes()[0 if n_spatial == 2 else 1]  # 2D or 3D limit
     if max_size is not None:
-        data = _downsample_data(data, max_size)
+        data = _downsample_data(data, max_size, n_spatial=n_spatial)
 
     return data
 

--- a/src/scenex/adaptors/_pygfx/_volume.py
+++ b/src/scenex/adaptors/_pygfx/_volume.py
@@ -7,7 +7,9 @@ import numpy as np
 import pygfx
 
 from scenex.adaptors._base import VolumeAdaptor
-from scenex.adaptors._pygfx._image import DOWNCASTS
+from scenex.adaptors._pygfx._image import (
+    _coerce_data,
+)
 
 from ._node import Node
 
@@ -25,12 +27,12 @@ class Volume(Node, VolumeAdaptor):
 
     _pygfx_node: pygfx.Volume
     _material: pygfx.VolumeBasicMaterial
-    _geometry: pygfx.Geometry
 
     def __init__(self, volume: model.Volume, **backend_kwargs: Any) -> None:
-        self._snx_set_data(volume.data)
+        self._model = volume
         self._snx_set_render_mode(volume.render_mode, volume.interpolation)
-        self._pygfx_node = pygfx.Volume(self._geometry, self._material)
+        self._pygfx_node = pygfx.Volume(material=self._material)
+        self._snx_set_data(volume.data)
 
     def _snx_set_cmap(self, arg: Colormap) -> None:
         self._material.map = arg.to_pygfx()
@@ -49,26 +51,37 @@ class Volume(Node, VolumeAdaptor):
             arg = "linear"
         self._material.interpolation = arg
 
-    def _create_texture(self, data: np.ndarray) -> pygfx.Texture:
-        if data.ndim != 3:
-            raise Exception("Volumes must be 3-dimensional")
-        if data.dtype in DOWNCASTS:
-            cast_to = DOWNCASTS[data.dtype]
-            # pygfx doesn't support 64-bit dtypes; downcast transparently.
-            # The user hasn't done anything wrong — this is a backend limitation.
-            logger.warning(
-                "Downcasting volume data from %s to %s for pygfx compatibility",
-                data.dtype.name,
-                cast_to.name,
-            )
-            data = data.astype(cast_to)
-        return pygfx.Texture(data, dim=data.ndim)
+    def _snx_set_transform(self, arg: model.Transform) -> None:
+        if not hasattr(self, "_pygfx_node"):
+            return  # _snx_set_data hasn't run yet to set initial factors
+        x_fac = self._model.data.shape[2] / self._texture.size[0]
+        y_fac = self._model.data.shape[1] / self._texture.size[1]
+        z_fac = self._model.data.shape[0] / self._texture.size[2]
+        self._pygfx_node.local.matrix = (
+            arg.scaled((x_fac, y_fac, z_fac))
+            .translated((0.5 * (x_fac - 1), 0.5 * (y_fac - 1), 0.5 * (z_fac - 1)))
+            .root.T
+        )
 
     def _snx_set_data(self, data: ArrayLike) -> None:
-        self._texture = self._create_texture(np.asanyarray(data))
-        self._geometry = pygfx.Geometry(grid=self._texture)
-        if hasattr(self, "_pygfx_node"):
-            self._pygfx_node.geometry = self._geometry
+        arr = np.asanyarray(data)
+        if arr.ndim != 3:
+            raise Exception("Volumes must be 3-dimensional")
+        processed = _coerce_data(arr, n_spatial=3)
+
+        current: pygfx.Texture | None = getattr(self, "_texture", None)
+        if current is not None and _can_reuse_volume(current, processed):
+            # Reuse the existing texture: overwrite its buffer and mark dirty.
+            current.data[:] = processed  # pyright: ignore
+            current.update_full()
+        else:
+            # Copy so later in-place reuse won't mutate the originally-passed array.
+            new_buffer = processed.copy()
+            self._texture = pygfx.Texture(new_buffer, dim=new_buffer.ndim)
+            self._pygfx_node.geometry = pygfx.Geometry(grid=self._texture)
+
+        # Keep transform compensation in sync whenever data or factors change.
+        self._snx_set_transform(self._model.transform)
 
     def _snx_set_render_mode(
         self,
@@ -95,3 +108,12 @@ class Volume(Node, VolumeAdaptor):
 
         if hasattr(self, "_pygfx_node"):
             self._pygfx_node.material = self._material
+
+
+def _can_reuse_volume(texture: pygfx.Texture, processed: np.ndarray) -> bool:
+    """True if *texture* can hold *processed* without reallocation."""
+    return (
+        texture.data is not None
+        and texture.data.shape == processed.shape
+        and texture.data.dtype == processed.dtype
+    )

--- a/src/scenex/adaptors/_pygfx/_volume.py
+++ b/src/scenex/adaptors/_pygfx/_volume.py
@@ -54,6 +54,9 @@ class Volume(Node, VolumeAdaptor):
     def _snx_set_transform(self, arg: model.Transform) -> None:
         if not hasattr(self, "_pygfx_node"):
             return  # _snx_set_data hasn't run yet to set initial factors
+        # Compensate for downscaled textures
+        # NOTE that image axes are ZYX in model space
+        # but the pygfx Texture shape will be (X, Y, Z).
         x_fac = self._model.data.shape[2] / self._texture.size[0]
         y_fac = self._model.data.shape[1] / self._texture.size[1]
         z_fac = self._model.data.shape[0] / self._texture.size[2]
@@ -67,11 +70,13 @@ class Volume(Node, VolumeAdaptor):
         arr = np.asanyarray(data)
         if arr.ndim != 3:
             raise Exception("Volumes must be 3-dimensional")
+        # Coerce the data to something that can be displayed by pygfx
         processed = _coerce_data(arr, n_spatial=3)
 
+        # If we have a texture already, see whether we can reuse it:
         current: pygfx.Texture | None = getattr(self, "_texture", None)
         if current is not None and _can_reuse_volume(current, processed):
-            # Reuse the existing texture: overwrite its buffer and mark dirty.
+            # To reuse, we overwrite its buffer and mark dirty.
             current.data[:] = processed  # pyright: ignore
             current.update_full()
         else:

--- a/src/scenex/adaptors/_vispy/_image.py
+++ b/src/scenex/adaptors/_vispy/_image.py
@@ -60,9 +60,11 @@ class Image(Node, ImageAdaptor):
     def _snx_set_transform(self, arg: Transform) -> None:
         # Offset accounting for vispy's pixel centers at half-integer locations
         offset = arg.map([-0.5, -0.5, 0, 0])
-        x_fac = self._model.data.shape[0] / self._vispy_node._data.shape[0]  # pyright: ignore
-        y_fac = self._model.data.shape[1] / self._vispy_node._data.shape[1]  # pyright: ignore
-        super()._snx_set_transform(arg.scaled((y_fac, x_fac, 1)).translated(offset))
+        # Compensate for downscaled textures
+        # Note that image axes are YX
+        y_fac = self._model.data.shape[0] / self._vispy_node._data.shape[0]  # pyright: ignore
+        x_fac = self._model.data.shape[1] / self._vispy_node._data.shape[1]  # pyright: ignore
+        super()._snx_set_transform(arg.scaled((x_fac, y_fac, 1)).translated(offset))
 
     def _snx_set_cmap(self, arg: Colormap) -> None:
         self._vispy_node.cmap = arg.to_vispy()

--- a/src/scenex/adaptors/_vispy/_image.py
+++ b/src/scenex/adaptors/_vispy/_image.py
@@ -1,20 +1,45 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import logging
+from contextlib import contextmanager
+from functools import lru_cache
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
+import numpy as np
 import vispy.scene
 import vispy.visuals
+from vispy.app import Canvas
+from vispy.gloo import gl
+from vispy.gloo.context import get_current_canvas
 
 from scenex.adaptors._base import ImageAdaptor
 
 from ._node import Node
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from cmap import Colormap
     from numpy.typing import ArrayLike
 
     from scenex import model
     from scenex.model._transform import Transform
+
+logger = logging.getLogger("scenex.adaptors.vispy")
+
+# Certain numpy data types are not supported by vispy. We downcast them to another type
+# defined in this dict.
+# See the following link for supported data types (subject to change):
+# https://github.com/vispy/vispy/blob/0a6da357f091bc3966abee805ff01914105e0979/vispy/visuals/_scalable_textures.py#L370
+DOWNCASTS: dict[np.dtype, np.dtype] = {
+    # VisPy only supports 32-bit floats
+    np.dtype("float64"): np.dtype("float32"),
+    # Vispy only supports <=uint16, and no signed options
+    np.dtype("int32"): np.dtype("uint16"),
+    np.dtype("int64"): np.dtype("uint16"),
+    np.dtype("uint32"): np.dtype("uint16"),
+    np.dtype("uint64"): np.dtype("uint16"),
+}
 
 
 class Image(Node, ImageAdaptor):
@@ -23,8 +48,11 @@ class Image(Node, ImageAdaptor):
     _vispy_node: vispy.visuals.ImageVisual
 
     def __init__(self, image: model.Image, **backend_kwargs: Any) -> None:
+        self._model = image
         self._vispy_node = vispy.scene.Image(
-            data=image.data, texture_format="auto", **backend_kwargs
+            data=_coerce_data(image.data, n_spatial=2),
+            texture_format="auto",
+            **backend_kwargs,
         )
         self._snx_set_data(image.data)
         self._vispy_node.visible = True
@@ -32,7 +60,9 @@ class Image(Node, ImageAdaptor):
     def _snx_set_transform(self, arg: Transform) -> None:
         # Offset accounting for vispy's pixel centers at half-integer locations
         offset = arg.map([-0.5, -0.5, 0, 0])
-        super()._snx_set_transform(arg.translated(offset))
+        x_fac = self._model.data.shape[0] / self._vispy_node._data.shape[0]  # pyright: ignore
+        y_fac = self._model.data.shape[1] / self._vispy_node._data.shape[1]  # pyright: ignore
+        super()._snx_set_transform(arg.scaled((y_fac, x_fac, 1)).translated(offset))
 
     def _snx_set_cmap(self, arg: Colormap) -> None:
         self._vispy_node.cmap = arg.to_vispy()
@@ -51,5 +81,108 @@ class Image(Node, ImageAdaptor):
         self._vispy_node.update()
 
     def _snx_set_data(self, data: ArrayLike) -> None:
-        self._vispy_node.set_data(data)
+        processed = _coerce_data(data, n_spatial=2)
+        self._vispy_node.set_data(processed)
         self._vispy_node.update()
+
+        # Keep transform compensation in sync whenever factors change.
+        self._snx_set_transform(self._model.transform)
+
+
+T = TypeVar("T", bound="np.ndarray | None")
+
+
+@contextmanager
+def _opengl_context() -> Generator[None, None, None]:
+    """Assure we are running with a valid OpenGL context.
+
+    Only create a Canvas is one doesn't exist. Creating and closing a
+    Canvas causes vispy to process Qt events which can cause problems.
+    """
+    canvas = Canvas(show=False) if get_current_canvas() is None else None
+    try:
+        yield
+    finally:
+        if canvas is not None:
+            canvas.close()
+
+
+@lru_cache(maxsize=1)
+def _get_max_texture_sizes() -> tuple[int | None, int | None]:
+    """Return the maximum texture sizes for 2D and 3D rendering.
+
+    Returns
+    -------
+    Tuple[int | None, int | None]
+        The max textures sizes for (2d, 3d) rendering.
+    """
+    with _opengl_context():
+        max_size_2d = gl.glGetParameter(gl.GL_MAX_TEXTURE_SIZE)
+
+    if not max_size_2d:
+        max_size_2d = None
+
+    # vispy/gloo doesn't provide the GL_MAX_3D_TEXTURE_SIZE location,
+    # but it can be found in this list of constants
+    # http://pyopengl.sourceforge.net/documentation/pydoc/OpenGL.GL.html
+    with _opengl_context():
+        GL_MAX_3D_TEXTURE_SIZE = 32883
+        max_size_3d = gl.glGetParameter(GL_MAX_3D_TEXTURE_SIZE)
+
+    if not max_size_3d:
+        max_size_3d = None
+
+    return max_size_2d, max_size_3d
+
+
+def _downsample_data(data: np.ndarray, max_size: int, n_spatial: int) -> np.ndarray:
+    """Downsample the spatial axes of *data* so none exceeds *max_size*.
+
+    Uses a strided NumPy view (no copy). Any trailing non-spatial axis (e.g. a
+    colour channel) is left untouched.
+
+    Returns the (possibly downsampled) array.
+    """
+    # If the data has more than n_spatial axes, assume the last one is a channel (RGBA).
+    has_channel = data.ndim > n_spatial
+    strides = tuple(
+        int(np.ceil(s / max_size)) if s > max_size else 1
+        for s in data.shape[:n_spatial]
+    )
+    if all(s == 1 for s in strides):
+        return data
+    logger.warning(
+        "Data shape %s exceeds max texture dimension (%d) and will be "
+        "downsampled for rendering (strides: %s).",
+        data.shape,
+        max_size,
+        strides,
+    )
+    slices: tuple[slice, ...] = tuple(slice(None, None, s) for s in strides)
+    if has_channel:
+        slices = (*slices, slice(None))
+    return data[slices]
+
+
+def _coerce_data(data: ArrayLike, n_spatial: Literal[2, 3]) -> np.ndarray:
+    """Downcast and downsample *data* for GPU upload.
+
+    Returns a (possibly strided) view — callers that need to own the
+    buffer must ``.copy()`` it.
+    """
+    data = np.asarray(data)
+    if data.dtype in DOWNCASTS:
+        cast_to = DOWNCASTS[data.dtype]
+        logger.warning(
+            "Downcasting %s data from %s to %s for vispy compatibility",
+            "image" if n_spatial == 2 else "volume",
+            data.dtype.name,
+            cast_to.name,
+        )
+        data = data.astype(cast_to)  # astype always returns a copy
+
+    max_size = _get_max_texture_sizes()[0 if n_spatial == 2 else 1]  # 2D or 3D limit
+    if max_size is not None:
+        data = _downsample_data(data, max_size, n_spatial=n_spatial)
+
+    return data

--- a/src/scenex/adaptors/_vispy/_image.py
+++ b/src/scenex/adaptors/_vispy/_image.py
@@ -96,7 +96,7 @@ class Image(Node, ImageAdaptor):
 def _opengl_context() -> Generator[None, None, None]:
     """Assure we are running with a valid OpenGL context.
 
-    Only create a Canvas is one doesn't exist. Creating and closing a
+    Only create a Canvas if one doesn't exist. Creating and closing a
     Canvas causes vispy to process Qt events which can cause problems.
     """
     canvas = Canvas(show=False) if get_current_canvas() is None else None

--- a/src/scenex/adaptors/_vispy/_image.py
+++ b/src/scenex/adaptors/_vispy/_image.py
@@ -86,9 +86,8 @@ class Image(Node, ImageAdaptor):
         # Coerce the data to something that can be displayed by vispy
         processed = _coerce_data(data, n_spatial=2)
         self._vispy_node.set_data(processed)
-        self._vispy_node.update()
 
-        # Keep transform compensation in sync whenever factors change.
+        # Update transform in case downsampling has changed the compensation factors.
         self._snx_set_transform(self._model.transform)
 
 

--- a/src/scenex/adaptors/_vispy/_image.py
+++ b/src/scenex/adaptors/_vispy/_image.py
@@ -83,6 +83,7 @@ class Image(Node, ImageAdaptor):
         self._vispy_node.update()
 
     def _snx_set_data(self, data: ArrayLike) -> None:
+        # Coerce the data to something that can be displayed by vispy
         processed = _coerce_data(data, n_spatial=2)
         self._vispy_node.set_data(processed)
         self._vispy_node.update()

--- a/src/scenex/adaptors/_vispy/_image.py
+++ b/src/scenex/adaptors/_vispy/_image.py
@@ -27,18 +27,21 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("scenex.adaptors.vispy")
 
-# Certain numpy data types are not supported by vispy. We downcast them to another type
+# Certain numpy data types are not supported by vispy. We cast them to another type
 # defined in this dict.
 # See the following link for supported data types (subject to change):
 # https://github.com/vispy/vispy/blob/0a6da357f091bc3966abee805ff01914105e0979/vispy/visuals/_scalable_textures.py#L370
-DOWNCASTS: dict[np.dtype, np.dtype] = {
+CASTS: dict[np.dtype, np.dtype] = {
     # VisPy only supports 32-bit floats
     np.dtype("float64"): np.dtype("float32"),
-    # Vispy only supports <=uint16, and no signed options
-    np.dtype("int32"): np.dtype("uint16"),
-    np.dtype("int64"): np.dtype("uint16"),
-    np.dtype("uint32"): np.dtype("uint16"),
-    np.dtype("uint64"): np.dtype("uint16"),
+    # Vispy only supports <=uint16, and no signed options. Given the options of
+    # downcasting to uint16 (causing clipping/wrap around) or float32 (which can
+    # represent the full range of int32/64) we choose the latter. We may lose some
+    # precision for large integers, but this is likely less bad than downcasting
+    np.dtype("int32"): np.dtype("float32"),
+    np.dtype("int64"): np.dtype("float32"),
+    np.dtype("uint32"): np.dtype("float32"),
+    np.dtype("uint64"): np.dtype("float32"),
 }
 
 
@@ -171,10 +174,10 @@ def _coerce_data(data: ArrayLike, n_spatial: Literal[2, 3]) -> np.ndarray:
     buffer must ``.copy()`` it.
     """
     data = np.asarray(data)
-    if data.dtype in DOWNCASTS:
-        cast_to = DOWNCASTS[data.dtype]
+    if data.dtype in CASTS:
+        cast_to = CASTS[data.dtype]
         logger.warning(
-            "Downcasting %s data from %s to %s for vispy compatibility",
+            "Casting %s data from %s to %s for vispy compatibility",
             "image" if n_spatial == 2 else "volume",
             data.dtype.name,
             cast_to.name,

--- a/src/scenex/adaptors/_vispy/_image.py
+++ b/src/scenex/adaptors/_vispy/_image.py
@@ -49,13 +49,14 @@ class Image(Node, ImageAdaptor):
 
     def __init__(self, image: model.Image, **backend_kwargs: Any) -> None:
         self._model = image
+        # Initialize the vispy node with dummy data
         self._vispy_node = vispy.scene.Image(
-            data=_coerce_data(image.data, n_spatial=2),
+            data=np.zeros((1, 1), dtype=np.uint8),
             texture_format="auto",
             **backend_kwargs,
         )
+        # Then set the data through the setter to ensure all processing is applied
         self._snx_set_data(image.data)
-        self._vispy_node.visible = True
 
     def _snx_set_transform(self, arg: Transform) -> None:
         # Offset accounting for vispy's pixel centers at half-integer locations

--- a/src/scenex/adaptors/_vispy/_image.py
+++ b/src/scenex/adaptors/_vispy/_image.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import vispy.scene
@@ -90,9 +90,6 @@ class Image(Node, ImageAdaptor):
 
         # Keep transform compensation in sync whenever factors change.
         self._snx_set_transform(self._model.transform)
-
-
-T = TypeVar("T", bound="np.ndarray | None")
 
 
 @contextmanager

--- a/src/scenex/adaptors/_vispy/_volume.py
+++ b/src/scenex/adaptors/_vispy/_volume.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import vispy.scene
 import vispy.visuals
 
@@ -25,12 +26,14 @@ class Volume(Node, VolumeAdaptor):
 
     def __init__(self, volume: model.Volume, **backend_kwargs: Any) -> None:
         self._model = volume
-        # TODO: What if volume.data is None?
+        # Initialize the vispy node with dummy data
         self._vispy_node = vispy.scene.Volume(
-            _coerce_data(volume.data, n_spatial=3),
+            vol=np.zeros((1, 1, 1), dtype=np.uint8),
             texture_format="auto",
             **backend_kwargs,
         )
+        # Then set the data through the setter to ensure all processing is applied
+        self._snx_set_data(volume.data)
 
     def _snx_set_transform(self, arg: Transform) -> None:
         # Offset accounting for vispy's pixel centers at half-integer locations

--- a/src/scenex/adaptors/_vispy/_volume.py
+++ b/src/scenex/adaptors/_vispy/_volume.py
@@ -35,6 +35,8 @@ class Volume(Node, VolumeAdaptor):
     def _snx_set_transform(self, arg: Transform) -> None:
         # Offset accounting for vispy's pixel centers at half-integer locations
         offset = arg.map([-0.5, -0.5, -0.5, 0])
+        # Compensate for downscaled textures
+        # Note that volume axes are ZYX
         x_fac = self._model.data.shape[2] / self._vispy_node._texture.shape[2]  # pyright: ignore
         y_fac = self._model.data.shape[1] / self._vispy_node._texture.shape[1]  # pyright: ignore
         z_fac = self._model.data.shape[0] / self._vispy_node._texture.shape[0]  # pyright: ignore
@@ -53,6 +55,7 @@ class Volume(Node, VolumeAdaptor):
         self._vispy_node.interpolation = arg
 
     def _snx_set_data(self, data: ArrayLike) -> None:
+        # Coerce the data to something that can be displayed by vispy
         processed = _coerce_data(data, n_spatial=3)
         self._vispy_node.set_data(processed)
 

--- a/src/scenex/adaptors/_vispy/_volume.py
+++ b/src/scenex/adaptors/_vispy/_volume.py
@@ -59,6 +59,9 @@ class Volume(Node, VolumeAdaptor):
         processed = _coerce_data(data, n_spatial=3)
         self._vispy_node.set_data(processed)
 
+        # Update transform in case downsampling has changed the compensation factors.
+        self._snx_set_transform(self._model.transform)
+
     def _snx_set_render_mode(
         self,
         data: model.RenderMode,

--- a/src/scenex/adaptors/_vispy/_volume.py
+++ b/src/scenex/adaptors/_vispy/_volume.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import numpy as np
 import vispy.scene
 import vispy.visuals
 
 from scenex.adaptors._base import VolumeAdaptor
+from scenex.adaptors._vispy._image import _coerce_data
 
 from ._node import Node
 
@@ -24,15 +24,21 @@ class Volume(Node, VolumeAdaptor):
     _vispy_node: vispy.visuals.VolumeVisual
 
     def __init__(self, volume: model.Volume, **backend_kwargs: Any) -> None:
+        self._model = volume
         # TODO: What if volume.data is None?
         self._vispy_node = vispy.scene.Volume(
-            volume.data, texture_format="auto", **backend_kwargs
+            _coerce_data(volume.data, n_spatial=3),
+            texture_format="auto",
+            **backend_kwargs,
         )
 
     def _snx_set_transform(self, arg: Transform) -> None:
         # Offset accounting for vispy's pixel centers at half-integer locations
         offset = arg.map([-0.5, -0.5, -0.5, 0])
-        super()._snx_set_transform(arg.translated(offset))
+        x_fac = self._model.data.shape[2] / self._vispy_node._texture.shape[2]  # pyright: ignore
+        y_fac = self._model.data.shape[1] / self._vispy_node._texture.shape[1]  # pyright: ignore
+        z_fac = self._model.data.shape[0] / self._vispy_node._texture.shape[0]  # pyright: ignore
+        super()._snx_set_transform(arg.scaled((x_fac, y_fac, z_fac)).translated(offset))
 
     def _snx_set_cmap(self, arg: Colormap) -> None:
         self._vispy_node.cmap = arg.to_vispy()
@@ -47,7 +53,8 @@ class Volume(Node, VolumeAdaptor):
         self._vispy_node.interpolation = arg
 
     def _snx_set_data(self, data: ArrayLike) -> None:
-        self._vispy_node.set_data(np.asarray(data))
+        processed = _coerce_data(data, n_spatial=3)
+        self._vispy_node.set_data(processed)
 
     def _snx_set_render_mode(
         self,

--- a/src/scenex/model/_nodes/image.py
+++ b/src/scenex/model/_nodes/image.py
@@ -86,15 +86,21 @@ class Image(Node):
         if not hasattr(self.data, "shape"):
             raise TypeError(f"{self.data} does not have a shape!")
         shape = self.data.shape
-        mi = [-0.5 for _d in shape] + [0] * (3 - len(shape))
-        ma = [d - 0.5 for d in shape] + [0] * (3 - len(shape))
-        return (tuple(mi), tuple(ma))  # type: ignore
+        min_x = -0.5
+        min_y = -0.5
+        min_z = 0 if len(shape) == 2 else -0.5
+        max_x = min_x + shape[-1]
+        max_y = min_y + shape[-2]
+        max_z = min_z + (0 if len(shape) == 2 else shape[-3])
+
+        return ((min_x, min_y, min_z), (max_x, max_y, max_z))
 
     def passes_through(self, ray: Ray) -> float | None:
         mi, _ma = self.bounding_box
         origin = self.transform.map(mi)[:3]
-        u = self.transform.map((self.data.shape[0], 0, 0, 0))[:3]
-        v = self.transform.map((0, self.data.shape[1], 0, 0))[:3]
+        # Note that conventionally, image data is in (Y, X) order.
+        u = self.transform.map((self.data.shape[1], 0, 0, 0))[:3]
+        v = self.transform.map((0, self.data.shape[0], 0, 0))[:3]
         return _passes_through_parallelogram(ray, origin, u, v)
 
 

--- a/src/scenex/model/_nodes/image.py
+++ b/src/scenex/model/_nodes/image.py
@@ -88,10 +88,11 @@ class Image(Node):
         shape = self.data.shape
         min_x = -0.5
         min_y = -0.5
-        min_z = 0 if len(shape) == 2 else -0.5
-        max_x = min_x + shape[-1]
-        max_y = min_y + shape[-2]
-        max_z = min_z + (0 if len(shape) == 2 else shape[-3])
+        min_z = 0
+        # NOTE: the way this is written works for grayscale and RGB(A) images.
+        max_x = min_x + shape[1]
+        max_y = min_y + shape[0]
+        max_z = min_z
 
         return ((min_x, min_y, min_z), (max_x, max_y, max_z))
 

--- a/src/scenex/model/_nodes/volume.py
+++ b/src/scenex/model/_nodes/volume.py
@@ -9,6 +9,8 @@ from .image import Image, _passes_through_parallelogram
 if TYPE_CHECKING:
     from scenex.app.events._events import Ray
 
+    from .node import AABB
+
 RenderMode = Literal["iso", "mip"]
 
 
@@ -58,6 +60,20 @@ class Volume(Image):
             'ray; "iso" renders a surface at a specific intensity value.'
         ),
     )
+
+    @property  # TODO: Cache?
+    def bounding_box(self) -> AABB:
+        if not hasattr(self.data, "shape"):
+            raise TypeError(f"{self.data} does not have a shape!")
+        shape = self.data.shape
+        min_x = -0.5
+        min_y = -0.5
+        min_z = -0.5
+        max_x = min_x + shape[2]
+        max_y = min_y + shape[1]
+        max_z = min_z + shape[0]
+
+        return ((min_x, min_y, min_z), (max_x, max_y, max_z))
 
     def passes_through(self, ray: Ray) -> float | None:
         # The ray passes through our volume if it passes through any of the six faces

--- a/src/scenex/model/_nodes/volume.py
+++ b/src/scenex/model/_nodes/volume.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import Field
 
 from .image import Image, _passes_through_parallelogram
-from .node import AABB  # noqa: TC001
 
 if TYPE_CHECKING:
     from scenex.app.events._events import Ray
@@ -60,17 +59,10 @@ class Volume(Image):
         ),
     )
 
-    @property  # TODO: Cache?
-    def bounding_box(self) -> AABB:
-        bb = super().bounding_box
-        # We can reuse the image version, but the first dimension needs to be swapped
-        # To account for the ZYX convention.
-        return ((bb[0][1], bb[0][2], bb[0][0]), (bb[1][1], bb[1][2], bb[1][0]))
-
     def passes_through(self, ray: Ray) -> float | None:
         # The ray passes through our volume if it passes through any of the six faces
         mi, ma = self.bounding_box
-        d, w, h = self.data.shape
+        d, h, w = self.data.shape
 
         # We can describe each face using a parallelogram using:
         # A point for the Top, Left, and Front faces

--- a/tests/adaptors/_pygfx/test_image.py
+++ b/tests/adaptors/_pygfx/test_image.py
@@ -196,12 +196,12 @@ def test_texture_buffer_not_source_array(
     ("src_dtype", "expected_dtype"),
     [
         (np.float64, np.float32),
-        (np.int64, np.int32),
-        (np.uint64, np.uint32),
+        (np.int64, np.float32),
+        (np.uint64, np.float32),
     ],
 )
-def test_downcasting(src_dtype: np.dtype, expected_dtype: np.dtype) -> None:
-    """Pygfx does not allow 64-bit data. This test ensures 64-bit data is downcasted."""
+def test_casting(src_dtype: np.dtype, expected_dtype: np.dtype) -> None:
+    """Pygfx does not allow several dtypes. This test ensures those are casted."""
     rng = np.random.default_rng()
     if np.issubdtype(src_dtype, np.floating):
         data = rng.random((100, 100), dtype=src_dtype)

--- a/tests/adaptors/_pygfx/test_image.py
+++ b/tests/adaptors/_pygfx/test_image.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import cmap
 import numpy as np
+import pygfx
 import pytest
 
 import scenex as snx
@@ -9,11 +12,17 @@ import scenex.adaptors._pygfx as adaptors
 from scenex.adaptors import get_adaptor_registry
 from scenex.model._transform import Transform
 
+# In various tests, we want to make sure that Textures aren't being needlessly recreated
+# We patch the Texture class to count how many times it's called, but we need to be
+# careful to patch the correct path - i.e. the path where the ImageAdaptor looks up the
+# Texture class, not necessarily the path where it's defined.
+_TEXTURE_PATH = "scenex.adaptors._pygfx._image.pygfx.Texture"
+
 
 @pytest.fixture
 def image() -> snx.Image:
     return snx.Image(
-        data=np.random.randint(0, 255, (100, 100), dtype=np.uint8),
+        data=np.random.randint(0, 255, (200, 100), dtype=np.uint8),
         cmap=cmap.Colormap("viridis"),
     )
 
@@ -32,35 +41,35 @@ def test_transform(image: snx.Image, adaptor: adaptors.Image) -> None:
 
     # No Transform
     image.transform = Transform()
-    exp_bounds = np.asarray([[-0.5, -0.5, 0], [99.5, 99.5, 0]])
+    exp_bounds = np.asarray([[-0.5, -0.5, 0], [99.5, 199.5, 0]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Just Translation
     image.transform = Transform().translated((-10, -10))
-    exp_bounds = np.asarray([[-10.5, -10.5, 0], [89.5, 89.5, 0]])
+    exp_bounds = np.asarray([[-10.5, -10.5, 0], [89.5, 189.5, 0]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Just Scaling
     image.transform = Transform().scaled((0.5, 0.5, 0.5))
-    exp_bounds = np.asarray([[-0.25, -0.25, 0], [49.75, 49.75, 0]])
+    exp_bounds = np.asarray([[-0.25, -0.25, 0], [49.75, 99.75, 0]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Scaling then Translation
     image.transform = Transform().scaled((0.5, 0.5, 0.5)).translated((-10, -10))
-    exp_bounds = np.asarray([[-10.25, -10.25, 0], [39.75, 39.75, 0]])
+    exp_bounds = np.asarray([[-10.25, -10.25, 0], [39.75, 89.75, 0]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Translation then Scaling
     image.transform = Transform().translated((-10, -10)).scaled((0.5, 0.5, 0.5))
-    exp_bounds = np.asarray([[-5.25, -5.25, 0], [44.75, 44.75, 0]])
+    exp_bounds = np.asarray([[-5.25, -5.25, 0], [44.75, 94.75, 0]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
@@ -94,6 +103,93 @@ def test_rgb(image: snx.Image, adaptor: adaptors.Image) -> None:
         cmap.Colormap("blue").to_pygfx().texture.data,
         adaptor._pygfx_node.material.map.texture.data,  # type: ignore
     )
+
+
+def test_oversized_texture() -> None:
+    """Demonstrates that textures exceeding GPU dimension limits are downsampled.
+
+    When image data exceeds the GPU's max texture dimension, pygfx will raise a
+    GLError at render time (err=1281, invalid value). The adaptor should detect
+    oversized data and transparently downsample it (e.g. via a strided view) before
+    uploading, rather than failing at render time.
+    """
+    import wgpu
+
+    # Determine the GPU's max texture dimension
+    adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
+    device = adapter.request_device_sync()
+    max_dim = device.limits["max-texture-dimension-2d"]
+
+    # Create an image that exceeds the GPU limits
+    oversized_shape = (1, max_dim + 1)
+    image = snx.Image(
+        data=np.zeros(oversized_shape, dtype=np.uint8), cmap=cmap.Colormap("viridis")
+    )
+    # Create an adaptor for it
+    adaptor = image._get_adaptors(create=True)[0]
+    assert isinstance(adaptor, adaptors.Image)
+    # And check the texture was downsampled to fit within the GPU limits
+    assert adaptor._texture.data.shape == (  # pyright: ignore
+        oversized_shape[0],
+        (oversized_shape[1] + 1) // 2,
+    )
+    # But ensure that the adaptor's transform is still correctly compensating for the
+    # downsampling, so the image appears at the correct size
+    np.testing.assert_almost_equal(
+        adaptor._pygfx_node.get_world_bounding_box(), image.bounding_box
+    )
+
+
+def test_texture_reuse(image: snx.Image, adaptor: adaptors.Image) -> None:
+    """Updating data with the same shape and dtype reuses the existing texture."""
+    new_data = np.full(image.data.shape, 42, dtype=np.uint8)
+    with patch(_TEXTURE_PATH, wraps=pygfx.Texture) as mock_texture:
+        image.data = new_data
+    assert mock_texture.call_count == 0
+    np.testing.assert_array_equal(adaptor._texture.data, new_data)  # pyright: ignore
+
+
+def test_texture_recreated_on_shape_change(
+    image: snx.Image, adaptor: adaptors.Image
+) -> None:
+    """Updating data with a different shape creates a new texture."""
+    existing_shape = adaptor._texture.data.shape  # pyright: ignore
+    new_shape = (existing_shape[0] + 10, existing_shape[1] + 10)
+    with patch(_TEXTURE_PATH, wraps=pygfx.Texture) as mock_texture:
+        image.data = np.zeros(new_shape, dtype=np.uint8)
+    assert mock_texture.call_count == 1
+
+
+def test_texture_recreated_on_dtype_change(
+    image: snx.Image, adaptor: adaptors.Image
+) -> None:
+    """Updating data with a different dtype creates a new texture."""
+    assert adaptor._texture.data.dtype != np.float32  # pyright: ignore
+    with patch(_TEXTURE_PATH, wraps=pygfx.Texture) as mock_texture:
+        image.data = np.zeros((100, 100), dtype=np.float32)
+    assert mock_texture.call_count == 1
+
+
+def test_texture_recreated_on_ndim_change(
+    image: snx.Image, adaptor: adaptors.Image
+) -> None:
+    """Switching between grayscale and RGB creates a new texture."""
+    with patch(_TEXTURE_PATH, wraps=pygfx.Texture) as mock_texture:
+        image.data = np.zeros((100, 100, 3), dtype=np.uint8)
+    assert mock_texture.call_count == 1
+
+
+def test_texture_buffer_not_source_array(
+    image: snx.Image, adaptor: adaptors.Image
+) -> None:
+    """Reusing pygfx Textures opens the door to mutation - test it doesn't happen."""
+    old_data_actual = image.data
+    assert isinstance(old_data_actual, np.ndarray)
+    old_data_expected = old_data_actual.copy()
+    # Overwrite via same-shape update — triggers the in-place reuse path
+    image.data = old_data_actual + 1
+    # The first array must be unaffected
+    assert np.array_equal(old_data_actual, old_data_expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/adaptors/_pygfx/test_volume.py
+++ b/tests/adaptors/_pygfx/test_volume.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import numpy as np
 import pygfx
 import pytest
@@ -9,11 +11,17 @@ import scenex.adaptors._pygfx as adaptors
 from scenex.adaptors._auto import get_adaptor_registry
 from scenex.model import BlendMode, Transform
 
+# In various tests, we want to make sure that Textures aren't being needlessly recreated
+# We patch the Texture class to count how many times it's called, but we need to be
+# careful to patch the correct path - i.e. the path where the VolumeAdaptor looks up the
+# Texture class, not necessarily the path where it's defined.
+_TEXTURE_PATH = "scenex.adaptors._pygfx._volume.pygfx.Texture"
+
 
 @pytest.fixture
 def volume() -> snx.Volume:
     return snx.Volume(
-        data=np.random.randint(0, 255, (100, 100, 100), dtype=np.uint8),
+        data=np.random.randint(0, 255, (40, 30, 20), dtype=np.uint8),
     )
 
 
@@ -27,38 +35,33 @@ def adaptor(volume: snx.Volume) -> adaptors.Volume:
 def test_transform(volume: snx.Volume, adaptor: adaptors.Volume) -> None:
     # No Transform
     volume.transform = Transform()
-    exp_bounds = np.asarray([[-0.5, -0.5, -0.5], [99.5, 99.5, 99.5]])
+    exp_bounds = np.asarray([[-0.5, -0.5, -0.5], [19.5, 29.5, 39.5]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
-    assert bb is not None
-    assert np.array_equal(exp_bounds, bb)
+    np.testing.assert_array_almost_equal(exp_bounds, bb)
 
     # Just Translation
     volume.transform = Transform().translated((-10, -10, -10))
-    exp_bounds = np.asarray([[-10.5, -10.5, -10.5], [89.5, 89.5, 89.5]])
+    exp_bounds = np.asarray([[-10.5, -10.5, -10.5], [9.5, 19.5, 29.5]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
-    assert bb is not None
-    assert np.array_equal(exp_bounds, bb)
+    np.testing.assert_array_almost_equal(exp_bounds, bb)
 
     # Just Scaling
     volume.transform = Transform().scaled((0.5, 0.5, 0.5))
-    exp_bounds = np.asarray([[-0.25, -0.25, -0.25], [49.75, 49.75, 49.75]])
+    exp_bounds = np.asarray([[-0.25, -0.25, -0.25], [9.75, 14.75, 19.75]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
-    assert bb is not None
-    assert np.array_equal(exp_bounds, bb)
+    np.testing.assert_array_almost_equal(exp_bounds, bb)
 
     # Scaling then Translation
     volume.transform = Transform().scaled((0.5, 0.5, 0.5)).translated((-10, -10, -10))
-    exp_bounds = np.asarray([[-10.25, -10.25, -10.25], [39.75, 39.75, 39.75]])
+    exp_bounds = np.asarray([[-10.25, -10.25, -10.25], [-0.25, 4.75, 9.75]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
-    assert bb is not None
-    assert np.array_equal(exp_bounds, bb)
+    np.testing.assert_array_almost_equal(exp_bounds, bb)
 
     # Translation then Scaling
     volume.transform = Transform().translated((-10, -10, -10)).scaled((0.5, 0.5, 0.5))
-    exp_bounds = np.asarray([[-5.25, -5.25, -5.25], [44.75, 44.75, 44.75]])
+    exp_bounds = np.asarray([[-5.25, -5.25, -5.25], [4.75, 9.75, 14.75]])
     bb = adaptor._pygfx_node.get_world_bounding_box()
-    assert bb is not None
-    assert np.array_equal(exp_bounds, bb)
+    np.testing.assert_array_almost_equal(exp_bounds, bb)
 
 
 @pytest.mark.skipif(
@@ -96,3 +99,72 @@ def test_downcasting(
     adaptor = get_adaptor_registry().get_adaptor(volume, create=True)
     assert isinstance(adaptor, adaptors.Volume)
     assert adaptor._texture.data.dtype == expected_dtype  # pyright: ignore
+
+
+def test_oversized_texture() -> None:
+    """Demonstrates that textures exceeding GPU dimension limits are downsampled."""
+    import wgpu
+
+    # Determine the GPU's max texture dimension
+    adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
+    device = adapter.request_device_sync()
+    max_dim = device.limits["max-texture-dimension-3d"]
+
+    # Create an image that exceeds the GPU limits
+    oversized_shape = (1, 1, max_dim + 1)
+    volume = snx.Volume(data=np.zeros(oversized_shape, dtype=np.uint8))
+    # Create an adaptor for it
+    adaptor = get_adaptor_registry().get_adaptor(volume, create=True)
+    assert isinstance(adaptor, adaptors.Volume)
+    # And check the texture was downsampled to fit within the GPU limits
+    assert adaptor._texture.data.shape == (  # pyright: ignore
+        oversized_shape[0],
+        oversized_shape[1],
+        (oversized_shape[2] + 1) // 2,
+    )
+    # But ensure that the adaptor's transform is still correctly compensating for the
+    # downsampling, so the image appears at the correct size
+    np.testing.assert_almost_equal(
+        adaptor._pygfx_node.get_world_bounding_box(), volume.bounding_box
+    )
+
+
+def test_texture_reuse(volume: snx.Volume, adaptor: adaptors.Volume) -> None:
+    """Updating data with the same shape and dtype reuses the existing texture."""
+    new_data = np.full(volume.data.shape, 42, dtype=np.uint8)
+    with patch(_TEXTURE_PATH, wraps=pygfx.Texture) as mock_texture:
+        volume.data = new_data
+    assert mock_texture.call_count == 0
+    np.testing.assert_array_equal(adaptor._texture.data, new_data)  # pyright: ignore
+
+
+def test_texture_recreated_on_shape_change(
+    volume: snx.Volume, adaptor: adaptors.Volume
+) -> None:
+    """Updating data with a different shape creates a new texture."""
+    existing_shape = adaptor._texture.data.shape  # pyright: ignore
+    new_shape = tuple(s + 10 for s in existing_shape)
+    with patch(_TEXTURE_PATH, wraps=pygfx.Texture) as mock_texture:
+        volume.data = np.zeros(new_shape, dtype=np.uint8)
+    assert mock_texture.call_count == 1
+
+
+def test_texture_recreated_on_dtype_change(
+    volume: snx.Volume, adaptor: adaptors.Volume
+) -> None:
+    """Updating data with a different dtype creates a new texture."""
+    assert adaptor._texture.data.dtype != np.float32  # pyright: ignore
+    with patch(_TEXTURE_PATH, wraps=pygfx.Texture) as mock_texture:
+        volume.data = np.zeros((10, 10, 10), dtype=np.float32)
+    assert mock_texture.call_count == 1
+
+
+def test_texture_buffer_not_source_array(
+    volume: snx.Volume, adaptor: adaptors.Volume
+) -> None:
+    """Reusing pygfx Textures opens the door to mutation - test it doesn't happen."""
+    old_data_actual = volume.data
+    assert isinstance(old_data_actual, np.ndarray)
+    old_data_expected = old_data_actual.copy()
+    volume.data = old_data_actual + 1
+    assert np.array_equal(old_data_actual, old_data_expected)

--- a/tests/adaptors/_pygfx/test_volume.py
+++ b/tests/adaptors/_pygfx/test_volume.py
@@ -82,14 +82,14 @@ def test_blending(volume: snx.Volume, adaptor: adaptors.Volume) -> None:
     ("src_dtype", "expected_dtype"),
     [
         (np.float64, np.float32),
-        (np.int64, np.int32),
-        (np.uint64, np.uint32),
+        (np.int64, np.float32),
+        (np.uint64, np.float32),
     ],
 )
-def test_downcasting(
+def test_casting(
     src_dtype: np.dtype, expected_dtype: np.dtype, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Pygfx does not allow 64-bit data. This test ensures 64-bit data is downcasted."""
+    """Pygfx does not allow several dtypes. This test ensures those are casted."""
     rng = np.random.default_rng()
     if np.issubdtype(src_dtype, np.floating):
         data = rng.random((3, 100, 100), dtype=src_dtype)

--- a/tests/adaptors/_vispy/test_image.py
+++ b/tests/adaptors/_vispy/test_image.py
@@ -17,8 +17,9 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def image() -> snx.Image:
+    # Width (x-axis) is 80 and Height (y-axis) is 100
     return snx.Image(
-        data=np.random.randint(0, 255, (100, 100), dtype=np.uint8),
+        data=np.random.randint(0, 255, (100, 80), dtype=np.uint8),
     )
 
 
@@ -32,35 +33,35 @@ def adaptor(image: snx.Image) -> adaptors.Image:
 def test_transform(image: snx.Image, adaptor: adaptors.Image) -> None:
     # No Transform
     image.transform = Transform()
-    exp_bounds = np.asarray([[-0.5, -0.5, 0], [99.5, 99.5, 0]])
+    exp_bounds = np.asarray([[-0.5, -0.5, 0], [79.5, 99.5, 0]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Just Translation
     image.transform = Transform().translated((-10, -10))
-    exp_bounds = np.asarray([[-10.5, -10.5, 0], [89.5, 89.5, 0]])
+    exp_bounds = np.asarray([[-10.5, -10.5, 0], [69.5, 89.5, 0]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Just Scaling
     image.transform = Transform().scaled((0.5, 0.5, 0.5))
-    exp_bounds = np.asarray([[-0.25, -0.25, 0], [49.75, 49.75, 0]])
+    exp_bounds = np.asarray([[-0.25, -0.25, 0], [39.75, 49.75, 0]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Scaling then Translation
     image.transform = Transform().scaled((0.5, 0.5, 0.5)).translated((-10, -10))
-    exp_bounds = np.asarray([[-10.25, -10.25, 0], [39.75, 39.75, 0]])
+    exp_bounds = np.asarray([[-10.25, -10.25, 0], [29.75, 39.75, 0]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Translation then Scaling
     image.transform = Transform().translated((-10, -10)).scaled((0.5, 0.5, 0.5))
-    exp_bounds = np.asarray([[-5.25, -5.25, 0], [44.75, 44.75, 0]])
+    exp_bounds = np.asarray([[-5.25, -5.25, 0], [34.75, 44.75, 0]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)

--- a/tests/adaptors/_vispy/test_image.py
+++ b/tests/adaptors/_vispy/test_image.py
@@ -100,14 +100,14 @@ def test_oversized_texture() -> None:
     ("src_dtype", "expected_dtype"),
     [
         (np.float64, np.float32),
-        (np.int32, np.uint16),
-        (np.int64, np.uint16),
-        (np.uint32, np.uint16),
-        (np.uint64, np.uint16),
+        (np.int32, np.float32),
+        (np.int64, np.float32),
+        (np.uint32, np.float32),
+        (np.uint64, np.float32),
     ],
 )
-def test_downcasting(src_dtype: np.dtype, expected_dtype: np.dtype) -> None:
-    """Vispy does not allow 64-bit data. This test ensures 64-bit data is downcasted."""
+def test_casting(src_dtype: np.dtype, expected_dtype: np.dtype) -> None:
+    """Vispy does not allow several dtypes. This test ensures those are casted."""
     rng = np.random.default_rng()
     if np.issubdtype(src_dtype, np.floating):
         data = rng.random((100, 100), dtype=src_dtype)

--- a/tests/adaptors/_vispy/test_image.py
+++ b/tests/adaptors/_vispy/test_image.py
@@ -8,6 +8,7 @@ import pytest
 import scenex as snx
 import scenex.adaptors._vispy as adaptors
 from scenex.adaptors._auto import get_adaptor_registry
+from scenex.adaptors._vispy._image import _get_max_texture_sizes
 from scenex.model._transform import Transform
 
 if TYPE_CHECKING:
@@ -63,6 +64,58 @@ def test_transform(image: snx.Image, adaptor: adaptors.Image) -> None:
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
+
+
+def test_oversized_texture() -> None:
+    """Demonstrates that textures exceeding GPU dimension limits are downsampled.
+
+    When image data exceeds the GPU's max texture dimension, vispy will silently send
+    smaller data (TODO: Better explanation - this particular size shows a single pixel)
+    The adaptor should detect oversized data and transparently downsample it (e.g. via a
+    strided view) before uploading, avoiding this erroneous behavior.
+    """
+    max_dim = _get_max_texture_sizes()[0]  # 2D limit
+    if max_dim is None:
+        pytest.skip("GPU does not report a max texture size, cannot test downsampling")
+
+    # Create an image that exceeds the GPU limits
+    oversized_shape = (1, max_dim + 1)
+    image = snx.Image(data=np.zeros(oversized_shape, dtype=np.uint8))
+    # Create an adaptor for it
+    adaptor = image._get_adaptors(create=True)[0]
+    assert isinstance(adaptor, adaptors.Image)
+    # And check the texture was downsampled to fit within the GPU limits
+    assert adaptor._vispy_node._data.shape == (  # pyright: ignore
+        oversized_shape[0],
+        (oversized_shape[1] + 1) // 2,
+    )
+    # But ensure that the adaptor's transform is still correctly compensating for the
+    # downsampling, so the image appears at the correct size
+    bb = _bounds(adaptor._vispy_node)
+    np.testing.assert_almost_equal(bb, image.bounding_box)
+
+
+@pytest.mark.parametrize(
+    ("src_dtype", "expected_dtype"),
+    [
+        (np.float64, np.float32),
+        (np.int32, np.uint16),
+        (np.int64, np.uint16),
+        (np.uint32, np.uint16),
+        (np.uint64, np.uint16),
+    ],
+)
+def test_downcasting(src_dtype: np.dtype, expected_dtype: np.dtype) -> None:
+    """Vispy does not allow 64-bit data. This test ensures 64-bit data is downcasted."""
+    rng = np.random.default_rng()
+    if np.issubdtype(src_dtype, np.floating):
+        data = rng.random((100, 100), dtype=src_dtype)
+    else:
+        data = rng.integers(0, 255, (100, 100), dtype=src_dtype)
+    image = snx.Image(data=data)
+    adaptor = get_adaptor_registry().get_adaptor(image, create=True)
+    assert isinstance(adaptor, adaptors.Image)
+    assert adaptor._vispy_node._data.dtype == expected_dtype  # pyright: ignore
 
 
 def _bounds(node: ImageVisual) -> np.ndarray:

--- a/tests/adaptors/_vispy/test_volume.py
+++ b/tests/adaptors/_vispy/test_volume.py
@@ -8,6 +8,7 @@ import pytest
 import scenex as snx
 import scenex.adaptors._vispy as adaptors
 from scenex.adaptors._auto import get_adaptor_registry
+from scenex.adaptors._vispy._image import _get_max_texture_sizes
 from scenex.model import BlendMode, Transform
 
 if TYPE_CHECKING:
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 @pytest.fixture
 def volume() -> snx.Volume:
     return snx.Volume(
-        data=np.random.randint(0, 255, (100, 100, 100), dtype=np.uint8),
+        data=np.random.randint(0, 255, (40, 30, 20), dtype=np.uint8),
     )
 
 
@@ -31,35 +32,35 @@ def adaptor(volume: snx.Volume) -> adaptors.Volume:
 def test_transform(volume: snx.Volume, adaptor: adaptors.Volume) -> None:
     # No Transform
     volume.transform = Transform()
-    exp_bounds = np.asarray([[-0.5, -0.5, -0.5], [99.5, 99.5, 99.5]])
+    exp_bounds = np.asarray([[-0.5, -0.5, -0.5], [19.5, 29.5, 39.5]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Just Translation
     volume.transform = Transform().translated((-10, -10, -10))
-    exp_bounds = np.asarray([[-10.5, -10.5, -10.5], [89.5, 89.5, 89.5]])
+    exp_bounds = np.asarray([[-10.5, -10.5, -10.5], [9.5, 19.5, 29.5]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Just Scaling
     volume.transform = Transform().scaled((0.5, 0.5, 0.5))
-    exp_bounds = np.asarray([[-0.25, -0.25, -0.25], [49.75, 49.75, 49.75]])
+    exp_bounds = np.asarray([[-0.25, -0.25, -0.25], [9.75, 14.75, 19.75]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Scaling then Translation
     volume.transform = Transform().scaled((0.5, 0.5, 0.5)).translated((-10, -10, -10))
-    exp_bounds = np.asarray([[-10.25, -10.25, -10.25], [39.75, 39.75, 39.75]])
+    exp_bounds = np.asarray([[-10.25, -10.25, -10.25], [-0.25, 4.75, 9.75]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
 
     # Translation then Scaling
     volume.transform = Transform().translated((-10, -10, -10)).scaled((0.5, 0.5, 0.5))
-    exp_bounds = np.asarray([[-5.25, -5.25, -5.25], [44.75, 44.75, 44.75]])
+    exp_bounds = np.asarray([[-5.25, -5.25, -5.25], [4.75, 9.75, 14.75]])
     bb = _bounds(adaptor._vispy_node)
     assert bb is not None
     assert np.array_equal(exp_bounds, bb)
@@ -81,6 +82,57 @@ def test_blending(volume: snx.Volume, adaptor: adaptors.Volume) -> None:
 
     volume.blending = BlendMode.OPAQUE
     adaptor._vispy_node.set_gl_state.assert_called_with(None, blend=False)
+
+
+@pytest.mark.parametrize(
+    ("src_dtype", "expected_dtype"),
+    [
+        (np.float64, np.float32),
+        (np.int32, np.uint16),
+        (np.int64, np.uint16),
+        (np.uint32, np.uint16),
+        (np.uint64, np.uint16),
+    ],
+)
+def test_downcasting(
+    src_dtype: np.dtype, expected_dtype: np.dtype, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Pygfx does not allow 64-bit data. This test ensures 64-bit data is downcasted."""
+    rng = np.random.default_rng()
+    if np.issubdtype(src_dtype, np.floating):
+        data = rng.random((3, 100, 100), dtype=src_dtype)
+    else:
+        data = rng.integers(0, 255, (3, 100, 100), dtype=src_dtype)
+    volume = snx.Volume(data=data)
+    adaptor = get_adaptor_registry().get_adaptor(volume, create=True)
+    assert isinstance(adaptor, adaptors.Volume)
+    assert adaptor._vispy_node._texture._data_dtype == expected_dtype  # pyright: ignore
+
+
+def test_oversized_texture() -> None:
+    """Demonstrates that textures exceeding GPU dimension limits are downsampled."""
+    max_dim = _get_max_texture_sizes()[1]  # 3D limit
+    if max_dim is None:
+        pytest.skip("GPU does not report a max texture size, cannot test downsampling")
+
+    # Create an image that exceeds the GPU limits in the X dimension
+    # NOTE volumes are ZYX order
+    oversized_shape = (1, 2, max_dim + 1)
+    volume = snx.Volume(data=np.zeros(oversized_shape, dtype=np.uint8))
+    # Create an adaptor for it
+    adaptor = get_adaptor_registry().get_adaptor(volume, create=True)
+    assert isinstance(adaptor, adaptors.Volume)
+    # And check the texture was downsampled to fit within the GPU limits
+    assert adaptor._vispy_node._texture.shape == (  # pyright: ignore
+        oversized_shape[0],
+        oversized_shape[1],
+        (oversized_shape[2] + 1) // 2,
+        1,
+    )
+    # But ensure that the adaptor's transform is still correctly compensating for the
+    # downsampling, so the image appears at the correct size
+    bb = _bounds(adaptor._vispy_node)
+    np.testing.assert_almost_equal(bb, volume.bounding_box)
 
 
 def _bounds(node: VolumeVisual) -> np.ndarray:

--- a/tests/adaptors/_vispy/test_volume.py
+++ b/tests/adaptors/_vispy/test_volume.py
@@ -88,16 +88,16 @@ def test_blending(volume: snx.Volume, adaptor: adaptors.Volume) -> None:
     ("src_dtype", "expected_dtype"),
     [
         (np.float64, np.float32),
-        (np.int32, np.uint16),
-        (np.int64, np.uint16),
-        (np.uint32, np.uint16),
-        (np.uint64, np.uint16),
+        (np.int32, np.float32),
+        (np.int64, np.float32),
+        (np.uint32, np.float32),
+        (np.uint64, np.float32),
     ],
 )
-def test_downcasting(
+def test_casting(
     src_dtype: np.dtype, expected_dtype: np.dtype, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Pygfx does not allow 64-bit data. This test ensures 64-bit data is downcasted."""
+    """Vispy does not allow several dtypes. This test ensures those are casted."""
     rng = np.random.default_rng()
     if np.issubdtype(src_dtype, np.floating):
         data = rng.random((3, 100, 100), dtype=src_dtype)

--- a/tests/model/_nodes/test_image.py
+++ b/tests/model/_nodes/test_image.py
@@ -11,7 +11,7 @@ from scenex.app.events import Ray
 @pytest.fixture
 def image() -> snx.Image:
     return snx.Image(
-        data=np.random.randint(0, 255, (100, 100), dtype=np.uint8),
+        data=np.random.randint(0, 255, (200, 100), dtype=np.uint8),
         cmap=cmap.Colormap("gray"),
         clims=(0, 255),
         gamma=1.0,
@@ -20,7 +20,7 @@ def image() -> snx.Image:
 
 
 def test_bounding_box(image: snx.Image) -> None:
-    exp_bounding_box = np.asarray(((-0.5, -0.5, 0), (99.5, 99.5, 0)))
+    exp_bounding_box = np.asarray(((-0.5, -0.5, 0), (99.5, 199.5, 0)))
     assert np.array_equal(exp_bounding_box, image.bounding_box)
 
 

--- a/tests/model/_nodes/test_image.py
+++ b/tests/model/_nodes/test_image.py
@@ -20,6 +20,14 @@ def image() -> snx.Image:
 
 
 def test_bounding_box(image: snx.Image) -> None:
+    """Bounding box sanity test."""
+    exp_bounding_box = np.asarray(((-0.5, -0.5, 0), (99.5, 199.5, 0)))
+    assert np.array_equal(exp_bounding_box, image.bounding_box)
+
+
+def test_rgb_bounding_box() -> None:
+    """Bounding box sanity test for an RGB image."""
+    image = snx.Image(data=np.random.randint(0, 255, (200, 100, 3), dtype=np.uint8))
     exp_bounding_box = np.asarray(((-0.5, -0.5, 0), (99.5, 199.5, 0)))
     assert np.array_equal(exp_bounding_box, image.bounding_box)
 

--- a/tests/model/_nodes/test_volume.py
+++ b/tests/model/_nodes/test_volume.py
@@ -10,13 +10,13 @@ from scenex.app.events import Ray
 @pytest.fixture
 def volume() -> snx.Volume:
     return snx.Volume(
-        data=np.random.randint(0, 255, (60, 100, 100), dtype=np.uint8),
+        data=np.random.randint(0, 255, (60, 200, 100), dtype=np.uint8),
     )
 
 
 def test_bounding_box(volume: snx.Volume) -> None:
     # Note that the volume has 60 z-slices. But depth comes last in the bounding box!
-    exp_bounding_box = np.asarray(((-0.5, -0.5, -0.5), (99.5, 99.5, 59.5)))
+    exp_bounding_box = np.asarray(((-0.5, -0.5, -0.5), (99.5, 199.5, 59.5)))
     assert np.array_equal(exp_bounding_box, volume.bounding_box)
 
 


### PR DESCRIPTION
This PR adds a couple features targeted at improving the pygfx backend.
1. Texture Downsampling - solves #59 
2. Texture reuse - this was something we did in ndv but didn't make it here.