### PR TITLE
pygfx: support Point symbols

### DIFF
--- a/src/scenex/adaptors/_pygfx/_points.py
+++ b/src/scenex/adaptors/_pygfx/_points.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -9,6 +10,8 @@ from scenex.adaptors._base import PointsAdaptor
 from scenex.model._color import ColorModel, UniformColor, VertexColors
 
 from ._node import Node
+
+logger = logging.getLogger("scenex.adaptors.pygfx")
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -97,7 +100,29 @@ class Points(Node, PointsAdaptor):
     def _snx_set_edge_width(self, edge_width: float) -> None:
         self._material.edge_width = edge_width
 
-    def _snx_set_symbol(self, symbol: str) -> None: ...
+    def _snx_set_symbol(self, symbol: str) -> None:
+        if symbol == "disc":
+            symbol = "circle"
+        elif symbol == "cross":
+            symbol = "plus"
+        elif symbol == "x":
+            symbol = "cross"
+
+        # TODO: Support these with custom marker textures (SDF).
+        # NOTE: vbar is kind of like pygfx's "tick", but tick just has an edge color.
+        if symbol in [
+            "arrow",
+            "clobber",
+            "vbar",
+            "hbar",
+            "tailed_arrow",
+            "star",
+            "cross_lines",
+        ]:
+            logger.warning("Unsupported symbol: %r", symbol)
+            return
+
+        self._material.marker = symbol
 
     def _snx_set_scaling(self, scaling: model.ScalingMode) -> None:
         self._material.size_space = SPACE_MAP[scaling]

--- a/src/scenex/adaptors/_pygfx/_points.py
+++ b/src/scenex/adaptors/_pygfx/_points.py
@@ -26,6 +26,24 @@ SPACE_MAP: Mapping[model.ScalingMode, Literal["model", "screen", "world"]] = {
     "visual": "model",
 }
 
+_UNSUPPORTED_SYMBOL = "UNSUPPORTED"
+_SYMBOL_MAP: Mapping[str, str] = {
+    # These symbols go under a different name
+    "disc": "circle",
+    "cross": "plus",
+    "x": "cross",
+    # These symbols are not currently supported in pygfx
+    # could be added with custom SDF marker textures
+    "arrow": _UNSUPPORTED_SYMBOL,
+    "clobber": _UNSUPPORTED_SYMBOL,
+    # NOTE: vbar is kind of like pygfx's "tick", but tick just has an edge color.
+    "vbar": _UNSUPPORTED_SYMBOL,
+    "hbar": _UNSUPPORTED_SYMBOL,
+    "tailed_arrow": _UNSUPPORTED_SYMBOL,
+    "star": _UNSUPPORTED_SYMBOL,
+    "cross_lines": _UNSUPPORTED_SYMBOL,
+}
+
 
 class Points(Node, PointsAdaptor):
     """Vispy backend adaptor for an Points node."""
@@ -101,28 +119,12 @@ class Points(Node, PointsAdaptor):
         self._material.edge_width = edge_width
 
     def _snx_set_symbol(self, symbol: str) -> None:
-        if symbol == "disc":
-            symbol = "circle"
-        elif symbol == "cross":
-            symbol = "plus"
-        elif symbol == "x":
-            symbol = "cross"
-
-        # TODO: Support these with custom marker textures (SDF).
-        # NOTE: vbar is kind of like pygfx's "tick", but tick just has an edge color.
-        if symbol in [
-            "arrow",
-            "clobber",
-            "vbar",
-            "hbar",
-            "tailed_arrow",
-            "star",
-            "cross_lines",
-        ]:
+        py_symbol = _SYMBOL_MAP.get(symbol, symbol)
+        if py_symbol == _UNSUPPORTED_SYMBOL:
             logger.warning("Unsupported symbol: %r", symbol)
             return
 
-        self._material.marker = symbol
+        self._material.marker = py_symbol
 
     def _snx_set_scaling(self, scaling: model.ScalingMode) -> None:
         self._material.size_space = SPACE_MAP[scaling]

--- a/tests/adaptors/_pygfx/test_points.py
+++ b/tests/adaptors/_pygfx/test_points.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import get_args
+
 import cmap
 import numpy as np
 import pygfx
@@ -8,6 +10,7 @@ import pytest
 import scenex as snx
 import scenex.adaptors._pygfx as adaptors
 from scenex.adaptors._auto import get_adaptor_registry
+from scenex.model import SymbolName
 
 
 @pytest.fixture
@@ -46,6 +49,43 @@ def test_points_data(points: snx.Points, adaptor: adaptors.Points) -> None:
     new_vertices = np.array([[5, 5, 0], [6, 6, 0]])
     points.vertices = new_vertices
     assert np.array_equal(geom.positions.data, new_vertices)
+
+
+_ALIASES: dict[SymbolName, str] = {
+    "disc": "circle",
+    "cross": "plus",
+    "x": "cross",
+}
+_UNSUPPORTED = {
+    "arrow",
+    "clobber",
+    "vbar",
+    "hbar",
+    "tailed_arrow",
+    "star",
+    "cross_lines",
+}
+
+
+@pytest.mark.parametrize("symbol", get_args(SymbolName))
+def test_points_symbol(
+    points: snx.Points,
+    adaptor: adaptors.Points,
+    caplog: pytest.LogCaptureFixture,
+    symbol: SymbolName,
+) -> None:
+    mat = adaptor._pygfx_node.material
+    assert isinstance(mat, pygfx.PointsMarkerMaterial)
+    assert mat.marker_mode == "uniform"
+
+    if symbol in _UNSUPPORTED:
+        with caplog.at_level("WARNING", logger="scenex.adaptors.pygfx"):
+            points.symbol = symbol
+        assert any(symbol in r.message for r in caplog.records)
+        return
+
+    points.symbol = symbol
+    assert mat.marker == _ALIASES.get(symbol, symbol)
 
 
 def test_points_size(points: snx.Points, adaptor: adaptors.Points) -> None:

--- a/tests/adaptors/_pygfx/test_points.py
+++ b/tests/adaptors/_pygfx/test_points.py
@@ -10,6 +10,7 @@ import pytest
 import scenex as snx
 import scenex.adaptors._pygfx as adaptors
 from scenex.adaptors._auto import get_adaptor_registry
+from scenex.adaptors._pygfx._points import _SYMBOL_MAP, _UNSUPPORTED_SYMBOL
 from scenex.model import SymbolName
 
 
@@ -51,22 +52,6 @@ def test_points_data(points: snx.Points, adaptor: adaptors.Points) -> None:
     assert np.array_equal(geom.positions.data, new_vertices)
 
 
-_ALIASES: dict[SymbolName, str] = {
-    "disc": "circle",
-    "cross": "plus",
-    "x": "cross",
-}
-_UNSUPPORTED = {
-    "arrow",
-    "clobber",
-    "vbar",
-    "hbar",
-    "tailed_arrow",
-    "star",
-    "cross_lines",
-}
-
-
 @pytest.mark.parametrize("symbol", get_args(SymbolName))
 def test_points_symbol(
     points: snx.Points,
@@ -77,15 +62,15 @@ def test_points_symbol(
     mat = adaptor._pygfx_node.material
     assert isinstance(mat, pygfx.PointsMarkerMaterial)
     assert mat.marker_mode == "uniform"
-
-    if symbol in _UNSUPPORTED:
+    py_symbol = _SYMBOL_MAP.get(symbol, symbol)
+    if py_symbol == _UNSUPPORTED_SYMBOL:
         with caplog.at_level("WARNING", logger="scenex.adaptors.pygfx"):
             points.symbol = symbol
-        assert any(symbol in r.message for r in caplog.records)
+        assert any(symbol in m for m in caplog.messages)
         return
 
     points.symbol = symbol
-    assert mat.marker == _ALIASES.get(symbol, symbol)
+    assert mat.marker == py_symbol
 
 
 def test_points_size(points: snx.Points, adaptor: adaptors.Points) -> None:


### PR DESCRIPTION
Somehow point symbols were overlooked to this point for pygfx. This PR adds them in.

@tlambert03, since you wrote `scenex.model.SymbolName`: there are many symbol types that pertain only to pygfx that aren't in that list, and conversely some symbols that the pygfx backend can't (without a custom marker type, which is some additional effort) handle. We should probably come up with a strategy to address that for each backend (maybe just make `SymbolName` the union of all supported markers, and only support some in each backend?) - but we can address this in another PR, for sure