### PR TITLE
Vispy: avoid depth test when blending

### DIFF
--- a/src/scenex/adaptors/_vispy/_node.py
+++ b/src/scenex/adaptors/_vispy/_node.py
@@ -64,11 +64,14 @@ class Node(NodeAdaptor[TNode, TObj], Generic[TNode, TObj]):
 
     def _snx_set_blending(self, arg: model.BlendMode) -> None:
         if hasattr(self._vispy_node, "set_gl_state"):
-            if arg == model.BlendMode.OPAQUE:
-                # for opaque, we need to disable blending
-                self._vispy_node.set_gl_state(None, blend=False)  # pyright: ignore
-            else:
-                self._vispy_node.set_gl_state(BLEND_MODES[arg], depth_test=False)  # pyright: ignore
+            # set_gl_state takes a preset and optional additional modifiers.
+            # The presets can be found in vispy.gloo.wrappers.GL_PRESETS
+            preset = BLEND_MODES.get(arg, "opaque")
+            # We want blending for alpha and additive modes
+            blend = arg in [model.BlendMode.ADDITIVE, model.BlendMode.ALPHA]
+            # If we aren't blending, we need depth testing
+            depth_test = not blend
+            self._vispy_node.set_gl_state(preset, blend=blend, depth_test=depth_test)
 
     def _snx_add_node(self, node: model.Node) -> None:
         # create if it doesn't exist

--- a/src/scenex/adaptors/_vispy/_node.py
+++ b/src/scenex/adaptors/_vispy/_node.py
@@ -68,7 +68,7 @@ class Node(NodeAdaptor[TNode, TObj], Generic[TNode, TObj]):
                 # for opaque, we need to disable blending
                 self._vispy_node.set_gl_state(None, blend=False)  # pyright: ignore
             else:
-                self._vispy_node.set_gl_state(BLEND_MODES[arg])  # pyright: ignore
+                self._vispy_node.set_gl_state(BLEND_MODES[arg], depth_test=False)  # pyright: ignore
 
     def _snx_add_node(self, node: model.Node) -> None:
         # create if it doesn't exist

--- a/tests/adaptors/_vispy/test_volume.py
+++ b/tests/adaptors/_vispy/test_volume.py
@@ -75,13 +75,19 @@ def test_blending(volume: snx.Volume, adaptor: adaptors.Volume) -> None:
     adaptor._vispy_node.set_gl_state = MagicMock()
 
     volume.blending = BlendMode.ADDITIVE
-    adaptor._vispy_node.set_gl_state.assert_called_with("additive", depth_test=False)
+    adaptor._vispy_node.set_gl_state.assert_called_with(
+        "additive", blend=True, depth_test=False
+    )
 
     volume.blending = BlendMode.ALPHA
-    adaptor._vispy_node.set_gl_state.assert_called_with("translucent", depth_test=False)
+    adaptor._vispy_node.set_gl_state.assert_called_with(
+        "translucent", blend=True, depth_test=False
+    )
 
     volume.blending = BlendMode.OPAQUE
-    adaptor._vispy_node.set_gl_state.assert_called_with(None, blend=False)
+    adaptor._vispy_node.set_gl_state.assert_called_with(
+        "opaque", blend=False, depth_test=True
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/adaptors/_vispy/test_volume.py
+++ b/tests/adaptors/_vispy/test_volume.py
@@ -75,10 +75,10 @@ def test_blending(volume: snx.Volume, adaptor: adaptors.Volume) -> None:
     adaptor._vispy_node.set_gl_state = MagicMock()
 
     volume.blending = BlendMode.ADDITIVE
-    adaptor._vispy_node.set_gl_state.assert_called_with("additive")
+    adaptor._vispy_node.set_gl_state.assert_called_with("additive", depth_test=False)
 
     volume.blending = BlendMode.ALPHA
-    adaptor._vispy_node.set_gl_state.assert_called_with("translucent")
+    adaptor._vispy_node.set_gl_state.assert_called_with("translucent", depth_test=False)
 
     volume.blending = BlendMode.OPAQUE
     adaptor._vispy_node.set_gl_state.assert_called_with(None, blend=False)


### PR DESCRIPTION
The vispy backend does depth testing for all blending modes, which, bluntly speaking, breaks transparency. This PR  disables depth testing for blending modes where *some* sort of blending should occur.