### PR TITLE
Orthographic projection robustness

### DIFF
--- a/src/scenex/utils/projections.py
+++ b/src/scenex/utils/projections.py
@@ -49,9 +49,10 @@ def orthographic(width: float = 1, height: float = 1, depth: float = 1) -> Trans
         # Negative values would flip the view, an unlikely user intention.
         # But it could be allowed if there's a good reason...
         raise ValueError("Orthographic projection parameters must be positive.")
-    width = max(width, 1e-6)
-    height = max(height, 1e-6)
-    depth = max(depth, 1e-6)
+    # REALLY small values could cause overflow in division, so we clamp to a min value.
+    width = max(width, 1e-200)
+    height = max(height, 1e-200)
+    depth = max(depth, 1e-200)
     return Transform().scaled((2 / width, 2 / height, -2 / depth))
 
 

--- a/src/scenex/utils/projections.py
+++ b/src/scenex/utils/projections.py
@@ -45,9 +45,11 @@ def orthographic(width: float = 1, height: float = 1, depth: float = 1) -> Trans
     projection: Transform
         A Transform matrix creating an orthographic camera view
     """
-    width = width if width else 1e-6
-    height = height if height else 1e-6
-    depth = depth if depth else 1e-6
+    if any(arg < 0 for arg in (width, height, depth)):
+        raise ValueError("Orthographic projection parameters must be positive.")
+    width = max(width, 1e-6)
+    height = max(height, 1e-6)
+    depth = max(depth, 1e-6)
     return Transform().scaled((2 / width, 2 / height, -2 / depth))
 
 

--- a/src/scenex/utils/projections.py
+++ b/src/scenex/utils/projections.py
@@ -46,6 +46,8 @@ def orthographic(width: float = 1, height: float = 1, depth: float = 1) -> Trans
         A Transform matrix creating an orthographic camera view
     """
     if any(arg < 0 for arg in (width, height, depth)):
+        # Negative values would flip the view, an unlikely user intention.
+        # But it could be allowed if there's a good reason...
         raise ValueError("Orthographic projection parameters must be positive.")
     width = max(width, 1e-6)
     height = max(height, 1e-6)

--- a/src/scenex/utils/projections.py
+++ b/src/scenex/utils/projections.py
@@ -26,16 +26,16 @@ def orthographic(width: float = 1, height: float = 1, depth: float = 1) -> Trans
     Parameters
     ----------
     width: float, optional
-        The width of the camera rectangular prism. Default 1 (mirroring the side length
-        of a unit cube).
+        The width of the camera rectangular prism. Must be positive. Default 1
+        (mirroring the side length of a unit cube).
     height: float, optional
-        The height of the camera rectangular prism. Default 1 (mirroring the side length
-        of a unit cube).
+        The height of the camera rectangular prism. Must be positive. Default 1
+        (mirroring the side length of a unit cube).
     depth: float, optional
-        The depth of the camera rectangular prism. The near and far clipping planes of
-        the resulting matrix become (-depth / 2) and (depth / 2) respectively. Default
-        1, increase (to render things farther away) or decrease (to increase
-        performance) as needed.
+        The depth of the camera rectangular prism. Must be positive. The near and far
+        clipping planes of the resulting matrix become (-depth / 2) and (depth / 2)
+        respectively. Default 1, increase (to render things farther away) or decrease
+        (to increase performance) as needed.
 
         TODO: Is this a good default? May want to consider some large number (1000?)
         instead
@@ -45,7 +45,7 @@ def orthographic(width: float = 1, height: float = 1, depth: float = 1) -> Trans
     projection: Transform
         A Transform matrix creating an orthographic camera view
     """
-    if any(arg < 0 for arg in (width, height, depth)):
+    if any(arg <= 0 for arg in (width, height, depth)):
         # Negative values would flip the view, an unlikely user intention.
         # But it could be allowed if there's a good reason...
         raise ValueError("Orthographic projection parameters must be positive.")

--- a/src/scenex/utils/projections.py
+++ b/src/scenex/utils/projections.py
@@ -127,7 +127,10 @@ def zoom_to_fit(
     """
     bb = view.scene.bounding_box
     center = np.mean(bb, axis=0) if bb else (0, 0, 0)
-    w, h, d = np.ptp(bb, axis=0) if bb else (1, 1, 1)
+    # Note that the np.maximum avoids bounding boxes with zero width, height, or depth.
+    # These wouldn't really be boxes, and would cause division by zero errors in
+    # projection matrix calculations
+    w, h, d = np.maximum(np.ptp(bb, axis=0) if bb else (1, 1, 1), 1e-6)
 
     # Apply aspect ratio correction only if requested
     if preserve_aspect_ratio:

--- a/tests/utils/test_projections.py
+++ b/tests/utils/test_projections.py
@@ -111,13 +111,13 @@ def test_perspective() -> None:
 def test_zoom_to_fit_orthographic() -> None:
     view = snx.View(
         scene=snx.Scene(
-            children=[snx.Points(vertices=np.asarray([[0, 100, 0], [100, 0, 1]]))]
+            children=[snx.Points(vertices=np.asarray([[0, 100, 0], [100, 0, 0]]))]
         )
     )
 
     zoom_to_fit(view, type="orthographic")
     # Assert the camera is moved to the center of the scene
-    assert view.camera.transform == snx.Transform().translated((50, 50, 0.5))
+    assert view.camera.transform == snx.Transform().translated((50, 50, 0))
     # Projection that maps world space to canvas coordinates
     tform = view.camera.transform.inv() @ view.camera.projection
     # Assert the camera projects [0, 0, 0] to NDC coordinates [-1, -1]
@@ -128,7 +128,7 @@ def test_zoom_to_fit_orthographic() -> None:
     zoom_factor = 0.9
     zoom_to_fit(view, type="orthographic", zoom_factor=zoom_factor)
     # Assert the camera is still at the center of the scene
-    assert view.camera.transform == snx.Transform().translated((50, 50, 0.5))
+    assert view.camera.transform == snx.Transform().translated((50, 50, 0))
     # Projection that maps world space to canvas coordinates
     tform = view.camera.transform.inv() @ view.camera.projection
     # Assert the camera projects [0, 0, 0] to NDC coordinates [-0.9, -0.9]

--- a/tests/utils/test_projections.py
+++ b/tests/utils/test_projections.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from pylinalg import vec_unproject
 
 import scenex as snx
@@ -57,6 +58,24 @@ def test_orthographic() -> None:
         ]
     )
     assert np.array_equal(exp_corners, vec_unproject(CORNERS, act_mat))
+
+    # Testing inappropriate values for width, height, depth
+    for i in range(3):
+        args = [1.0, 1.0, 1.0]
+        args[i] = 1e-6
+        exp_mat = orthographic(*args)
+        # Test negative values raise an error
+        args[i] = -1
+        with pytest.raises(ValueError):
+            orthographic(*args)
+        # Test zero values are replaced with very small values
+        args[i] = 0
+        act_mat = orthographic(*args)
+        assert np.allclose(exp_mat, act_mat, rtol=1e-10)
+        # Test extremely small values are replaced with very small values
+        args[i] = 1e-311
+        act_mat = orthographic(*args)
+        assert np.allclose(exp_mat, act_mat, rtol=1e-10)
 
 
 def test_perspective() -> None:

--- a/tests/utils/test_projections.py
+++ b/tests/utils/test_projections.py
@@ -71,7 +71,7 @@ def test_orthographic() -> None:
         with pytest.raises(ValueError):
             orthographic(*args)
         # Test extremely small values are replaced with very small values
-        args[i] = 1e-6
+        args[i] = 1e-200
         exp_mat = orthographic(*args)
         args[i] = 1e-311
         act_mat = orthographic(*args)

--- a/tests/utils/test_projections.py
+++ b/tests/utils/test_projections.py
@@ -62,17 +62,17 @@ def test_orthographic() -> None:
     # Testing inappropriate values for width, height, depth
     for i in range(3):
         args = [1.0, 1.0, 1.0]
-        args[i] = 1e-6
-        exp_mat = orthographic(*args)
         # Test negative values raise an error
         args[i] = -1
         with pytest.raises(ValueError):
             orthographic(*args)
-        # Test zero values are replaced with very small values
+        # Test zero values raise an error
         args[i] = 0
-        act_mat = orthographic(*args)
-        assert np.allclose(exp_mat, act_mat, rtol=1e-10)
+        with pytest.raises(ValueError):
+            orthographic(*args)
         # Test extremely small values are replaced with very small values
+        args[i] = 1e-6
+        exp_mat = orthographic(*args)
         args[i] = 1e-311
         act_mat = orthographic(*args)
         assert np.allclose(exp_mat, act_mat, rtol=1e-10)


### PR DESCRIPTION
This PR does some sanity checks on the parameters to `projections.orthographic`.