### PR TITLE
Bump max python version to 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version: "3.13"
+          python-version: "3.14"
       - run: uvx prek run --all-files
 
   test:
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
         gfx: [pygfx, vispy]
         canvas: [pyqt6, jupyter, wx]
         exclude:
@@ -61,6 +61,10 @@ jobs:
             canvas: pyqt6
             os: ubuntu-latest
           - python-version: "3.12"
+            gfx: pygfx
+            canvas: pyqt6
+            os: ubuntu-latest
+          - python-version: "3.13"
             gfx: pygfx
             canvas: pyqt6
             os: ubuntu-latest

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -42,16 +42,12 @@ jobs:
           fi
         env:
           DOCS_DEV: false
-          # TODO: Remove once maturin supports 3.14
-          UV_PYTHON: "3.13"
 
       - name: Deploy dev docs
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: uv run mike deploy --push --update-aliases dev
         env:
           DOCS_DEV: true
-          # TODO: Remove once maturin supports 3.14
-          UV_PYTHON: "3.13"
 
       # - name: Update default release docs
       #   run: mike set-default --push latest

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -42,12 +42,14 @@ jobs:
           fi
         env:
           DOCS_DEV: false
+          UV_PYTHON: "3.13"
 
       - name: Deploy dev docs
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: uv run mike deploy --push --update-aliases dev
         env:
           DOCS_DEV: true
+          UV_PYTHON: "3.13"
 
       # - name: Update default release docs
       #   run: mike set-default --push latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Typing :: Typed",
 ]
 dependencies = ["cmap>=0.5", "numpy>=1.24", "psygnal>=0.11.1", "pydantic>=2.10", "pylinalg"]


### PR DESCRIPTION
The main concern here is the (removal of the) hardcoding of the docs build to 3.13, but I think that's been fixed, as I built the docs locally with 3.14. 