### PR TITLE
Ignore child events in adaptors

### DIFF
--- a/src/scenex/adaptors/_base.py
+++ b/src/scenex/adaptors/_base.py
@@ -51,14 +51,25 @@ class Adaptor(ABC, Generic[TModel, TNative]):
             # Parent change events are handled by the parent adaptor.
             return
 
+        arg = info.args[0]
         try:
             name = self.SETTER_METHOD.format(name=signal_name)
             setter = getattr(self, name)
         except AttributeError as e:
+            if len(info.path) > 1:
+                # A length 2+ path implies a child event bubbling up to a parent that
+                # doesn't have a handler for it. Let's just ignore it.
+                nested_name = "".join(f".{step.attr}" for step in info.path)[1:]
+                logger.debug(
+                    "EVENT: %r ignored %s=%r (bubbling up, no handler)",
+                    type(self),
+                    nested_name,
+                    arg,
+                )
+                return
             logger.exception(e)
             return
 
-        arg = info.args[0]
         logger.debug("EVENT: %r -> %s=%r  ", type(self), signal_name, arg)
 
         try:


### PR DESCRIPTION
Currently, adaptors receive updates from changes to their own backing model via `Adaptor.handle_event`. Once this listener is set up, setting a field of the model to some other evented class will [relay child events](https://github.com/pyapp-kit/psygnal/blob/1e90319e62bf18207c318e65e63b5f68927baffd/src/psygnal/_group_descriptor.py#L469) back to the parent. 

Take, for example, a scenex `Camera`. If you make an adaptor for that camera, and then later set its controller to an `Orbit`, updating its center will relay that update to the `Camera`. Before these changes, that would log an error, because the `Camera` adaptors don't have a `_snx_set_center` method, *nor should they*.

I could foresee the relay being useful, so for now, if a relay occurs (checked here using `EmissionInfo.path`), we'll just log a debug message when the adaptor doesn't have the child 