### PR TITLE
Qt: Handle middle mouse button

### DIFF
--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -80,6 +80,8 @@ class QtEventFilter(QObject, EventFilter):
             return MouseButton.LEFT
         if btn == Qt.MouseButton.RightButton:
             return MouseButton.RIGHT
+        if btn == Qt.MouseButton.MiddleButton:
+            return MouseButton.MIDDLE
         if btn == Qt.MouseButton.NoButton:
             return MouseButton.NONE
 

--- a/tests/app/test_qt.py
+++ b/tests/app/test_qt.py
@@ -55,24 +55,30 @@ def evented_canvas(qtbot: QtBot) -> snx.Canvas:
     return canvas
 
 
-def test_mouse_press(evented_canvas: snx.Canvas, qtbot: QtBot) -> None:
+@pytest.mark.parametrize(
+    "qt_button, expected_buttons",
+    [
+        (Qt.MouseButton.LeftButton, MouseButton.LEFT),
+        (Qt.MouseButton.RightButton, MouseButton.RIGHT),
+        (Qt.MouseButton.MiddleButton, MouseButton.MIDDLE),
+    ],
+)
+def test_mouse_press(
+    evented_canvas: snx.Canvas,
+    qtbot: QtBot,
+    qt_button: Qt.MouseButton,
+    expected_buttons: MouseButton,
+) -> None:
     adaptor = evented_canvas._get_adaptors(create=True)[0]
     native = cast("CanvasAdaptor", adaptor)._snx_get_native()
     mock_filter = MagicMock(return_value=False)
     evented_canvas.set_event_filter(mock_filter)
 
     press_point = (5, 10)
-    # Press the left button
-    qtbot.mousePress(native, Qt.MouseButton.LeftButton, pos=QPoint(*press_point))
+    # Press the button
+    qtbot.mousePress(native, qt_button, pos=QPoint(*press_point))
     mock_filter.assert_called_once_with(
-        MousePressEvent(pos=press_point, buttons=MouseButton.LEFT)
-    )
-
-    mock_filter.reset_mock()
-    # Now press the right button
-    qtbot.mousePress(native, Qt.MouseButton.RightButton, pos=QPoint(*press_point))
-    mock_filter.assert_called_once_with(
-        MousePressEvent(pos=press_point, buttons=MouseButton.RIGHT)
+        MousePressEvent(pos=press_point, buttons=expected_buttons)
     )
 
 


### PR DESCRIPTION
Somehow, the middle mouse button was handled for wx and jupyter but not for qt 😦 