### PR TITLE
Remove some NotImplementedError usage

### DIFF
--- a/src/scenex/app/_auto.py
+++ b/src/scenex/app/_auto.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+from abc import abstractmethod
 from collections import OrderedDict
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from enum import Enum, auto
@@ -132,6 +133,7 @@ class App:
     determine_app : Function to determine which GUI backend to use
     """
 
+    @abstractmethod
     def create_app(self) -> Any:
         """Create the application instance, if not already created.
 
@@ -148,8 +150,9 @@ class App:
         -----
         Must be implemented by subclasses.
         """
-        raise NotImplementedError("Must be implemented by subclasses.")
+        ...
 
+    @abstractmethod
     def run(self) -> None:
         """Start the application event loop.
 
@@ -161,8 +164,9 @@ class App:
         -----
         Must be implemented by subclasses.
         """
-        raise NotImplementedError("Must be implemented by subclasses.")
+        ...
 
+    @abstractmethod
     def show(self, native_widget: Any, visible: bool) -> None:
         """Show or hide a native canvas widget.
 
@@ -177,8 +181,9 @@ class App:
         -----
         Must be implemented by subclasses.
         """
-        raise NotImplementedError("Must be implemented by subclasses.")
+        ...
 
+    @abstractmethod
     def install_event_filter(
         self, widget: Any, handler: Callable[[Event], bool]
     ) -> EventFilter:
@@ -205,8 +210,9 @@ class App:
         -----
         Must be implemented by subclasses.
         """
-        raise NotImplementedError("Must be implemented by subclasses.")
+        ...
 
+    @abstractmethod
     def process_events(self) -> None:
         """Yields the current thread to process all pending GUI events.
 
@@ -214,7 +220,7 @@ class App:
         -----
         Must be implemented by subclasses.
         """
-        raise NotImplementedError("Must be implemented by subclasses.")
+        ...
 
     def call_in_main_thread(
         self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs
@@ -250,6 +256,7 @@ class App:
         future.set_result(func(*args, **kwargs))
         return future
 
+    @abstractmethod
     def call_later(self, msec: int, func: Callable[[], None]) -> None:
         """Schedule a function to be called after a delay.
 
@@ -264,7 +271,7 @@ class App:
         -----
         Must be implemented by subclasses.
         """
-        raise NotImplementedError("Must be implemented by subclasses.")
+        ...
 
     def get_executor(self) -> Executor:
         """Return an executor for running tasks in background threads.
@@ -284,6 +291,8 @@ class App:
         return _thread_pool_executor()
 
     # ------------------------------ cursor API -------------------------------
+
+    @abstractmethod
     def set_cursor(self, native_widget: Any, cursor: CursorType) -> None:
         """Set the cursor on a native canvas widget.
 
@@ -296,7 +305,7 @@ class App:
         cursor : CursorType
             The type of cursor to set.
         """
-        raise NotImplementedError("Must be implemented by subclasses.")
+        ...
 
 
 @cache

--- a/src/scenex/app/_auto.py
+++ b/src/scenex/app/_auto.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from collections import OrderedDict
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from enum import Enum, auto
@@ -109,7 +109,7 @@ class CursorType(Enum):
     FDIAG_ARROW = auto()
 
 
-class App:
+class App(ABC):
     """Base class for GUI application wrappers.
 
     App provides an abstract interface for integrating scenex with different GUI

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -59,7 +59,14 @@ if TYPE_CHECKING:
     from scenex.app.events import Event
 
 
-class QtEventFilter(QObject, EventFilter):
+# QObject and EventFilter(ABC) use incompatible metaclasses. This combined metaclass
+# inherits from both so that QtEventFilter can subclass QObject and EventFilter,
+# avoiding MRO conflict.
+class _QtEventFilterMeta(type(EventFilter), type(QObject)):  # type: ignore
+    pass
+
+
+class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
     def __init__(self, widget: QWidget, handler: Callable[[Event], bool]) -> None:
         super().__init__()
         self._widget = widget

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -101,25 +101,27 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
             canvas_pos = (pos.x(), pos.y())
 
             etype = qevent.type()
-            btn = self.mouse_btn(qevent.button())
             if etype == QEvent.Type.MouseMove:
                 return MouseMoveEvent(
                     pos=canvas_pos,
                     buttons=self._active_buttons,
                 )
             elif etype == QEvent.Type.MouseButtonDblClick:
+                btn = self.mouse_btn(qevent.button())
                 self._active_buttons |= btn
                 return MouseDoublePressEvent(
                     pos=canvas_pos,
                     buttons=btn,
                 )
             elif etype == QEvent.Type.MouseButtonPress:
+                btn = self.mouse_btn(qevent.button())
                 self._active_buttons |= btn
                 return MousePressEvent(
                     pos=canvas_pos,
                     buttons=btn,
                 )
             elif etype == QEvent.Type.MouseButtonRelease:
+                btn = self.mouse_btn(qevent.button())
                 self._active_buttons &= ~btn
                 return MouseReleaseEvent(
                     pos=canvas_pos,

--- a/src/scenex/app/events/_events.py
+++ b/src/scenex/app/events/_events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from dataclasses import dataclass
 from enum import IntFlag, auto
 from typing import TYPE_CHECKING, NamedTuple, TypeAlias
@@ -394,6 +395,7 @@ class EventFilter:
     needed, ensuring proper cleanup and preventing memory leaks.
     """
 
+    @abstractmethod
     def uninstall(self) -> None:
         """Remove this event filter.
 
@@ -401,4 +403,4 @@ class EventFilter:
         longer be called for future events. After calling uninstall(), this
         EventFilter instance should not be used further.
         """
-        raise NotImplementedError("This method should be implemented by subclasses.")
+        ...

--- a/src/scenex/app/events/_events.py
+++ b/src/scenex/app/events/_events.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import IntFlag, auto
 from typing import TYPE_CHECKING, NamedTuple, TypeAlias
@@ -387,7 +387,7 @@ class KeyReleaseEvent(KeyEvent):
     pass
 
 
-class EventFilter:
+class EventFilter(ABC):
     """Base class for event filter handles.
 
     EventFilter instances are returned when installing event filters on views or

--- a/src/scenex/model/_nodes/camera.py
+++ b/src/scenex/model/_nodes/camera.py
@@ -235,7 +235,7 @@ class CameraController(BaseModel):
         need ``view.to_ray()`` to unproject screen-space event positions into world
         space, which requires both the camera matrices and the viewport dimensions.
         """
-        raise NotImplementedError
+        ...
 
 
 class PanZoom(CameraController):

--- a/src/scenex/model/_view.py
+++ b/src/scenex/model/_view.py
@@ -320,7 +320,7 @@ class ResizePolicy(EventedBase):
         view : View
             The view being resized.
         """
-        raise NotImplementedError
+        ...
 
 
 class Letterbox(ResizePolicy):


### PR DESCRIPTION
There is a valid use for `NotImplementedError` throwing within scenex - namely, when one backend may not support some model options.

This PR attempts to remove all of the other use cases, which are primarily used to denote abstract methods.