### PR TITLE
Avoid sporadic segfaults on CI

### DIFF
--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -72,6 +72,7 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
         self._widget = widget
         self._handler = handler
         self._active_buttons: MouseButton = MouseButton.NONE
+        widget.destroyed.connect(self.uninstall)
 
     def eventFilter(self, a0: QObject | None = None, a1: QEvent | None = None) -> bool:
         if isinstance(a0, QWidget) and not a0.signalsBlocked():

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -58,22 +58,6 @@ if TYPE_CHECKING:
     from scenex.app._auto import P, T
     from scenex.app.events import Event
 
-try:
-    from qtpy.sip import isdeleted
-
-    def is_qt_object_destroyed(obj: QObject) -> bool:
-        return isdeleted(obj)
-
-except ImportError:
-    try:
-        from qtpy.shiboken import isValid  # type: ignore[attr-defined]
-
-        def is_qt_object_destroyed(obj: QObject) -> bool:
-            return not isValid(obj)
-
-    except ImportError as e:
-        raise Exception("Could not delegate is_qt_object_destroyed check") from e
-
 
 # QObject and EventFilter(ABC) use incompatible metaclasses. This combined metaclass
 # inherits from both so that QtEventFilter can subclass QObject and EventFilter,
@@ -92,7 +76,7 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
     def eventFilter(self, a0: QObject | None = None, a1: QEvent | None = None) -> bool:
         if a0 is not self._widget:
             return False
-        if self._widget.signalsBlocked() or is_qt_object_destroyed(self._widget):
+        if self._widget.signalsBlocked():
             return False
         if isinstance(a1, QEvent) and (evt := self._convert_event(a1)):
             return self._handler(evt)
@@ -115,7 +99,7 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
 
     def _convert_event(self, qevent: QEvent) -> Event | None:
         """Convert a QEvent to a SceneX Event."""
-        if isinstance(qevent, QMouseEvent | QEnterEvent):
+        if isinstance(qevent, QMouseEvent):
             pos = qevent.position()
             canvas_pos = (pos.x(), pos.y())
 
@@ -146,11 +130,13 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
                     pos=canvas_pos,
                     buttons=btn,
                 )
-            elif etype == QEvent.Type.Enter:
-                return MouseEnterEvent(
-                    pos=canvas_pos,
-                    buttons=self._active_buttons,
-                )
+        elif isinstance(qevent, QEnterEvent):
+            pos = qevent.position()
+            canvas_pos = (pos.x(), pos.y())
+            return MouseEnterEvent(
+                pos=canvas_pos,
+                buttons=self._active_buttons,
+            )
 
         elif qevent.type() == QEvent.Type.Leave:
             return MouseLeaveEvent()

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -74,9 +74,13 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
         self._active_buttons: MouseButton = MouseButton.NONE
 
     def eventFilter(self, a0: QObject | None = None, a1: QEvent | None = None) -> bool:
-        if isinstance(a0, QWidget) and not a0.signalsBlocked():
-            if isinstance(a1, QEvent) and (evt := self._convert_event(a1)):
-                return self._handler(evt)
+        if not isinstance(a0, QWidget) or not isinstance(a1, QEvent):
+            return False
+        if a1.type() == QEvent.Type.Close:
+            self.uninstall()
+            return False
+        if not a0.signalsBlocked() and (evt := self._convert_event(a1)):
+            return self._handler(evt)
         return False
 
     def uninstall(self) -> None:

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -96,7 +96,7 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
 
     def _convert_event(self, qevent: QEvent) -> Event | None:
         """Convert a QEvent to a SceneX Event."""
-        if isinstance(qevent, QMouseEvent):
+        if isinstance(qevent, QMouseEvent | QEnterEvent):
             pos = qevent.position()
             canvas_pos = (pos.x(), pos.y())
 
@@ -127,13 +127,11 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
                     pos=canvas_pos,
                     buttons=btn,
                 )
-        elif isinstance(qevent, QEnterEvent):
-            pos = qevent.position()
-            canvas_pos = (pos.x(), pos.y())
-            return MouseEnterEvent(
-                pos=canvas_pos,
-                buttons=self._active_buttons,
-            )
+            elif etype == QEvent.Type.Enter:
+                return MouseEnterEvent(
+                    pos=canvas_pos,
+                    buttons=self._active_buttons,
+                )
 
         elif qevent.type() == QEvent.Type.Leave:
             return MouseLeaveEvent()

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -83,7 +83,12 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
         return False
 
     def uninstall(self) -> None:
-        self._widget.removeEventFilter(self)
+        try:
+            self._widget.removeEventFilter(self)
+        except RuntimeError:
+            # This can happen if the widget has already been deleted.
+            # In that case, we can just ignore it.
+            pass
 
     def mouse_btn(self, btn: Any) -> MouseButton:
         if btn == Qt.MouseButton.LeftButton:

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -58,6 +58,22 @@ if TYPE_CHECKING:
     from scenex.app._auto import P, T
     from scenex.app.events import Event
 
+try:
+    from qtpy.sip import isdeleted
+
+    def is_qt_object_destroyed(obj: QObject) -> bool:
+        return isdeleted(obj)
+
+except ImportError:
+    try:
+        from qtpy.shiboken import isValid  # type: ignore[attr-defined]
+
+        def is_qt_object_destroyed(obj: QObject) -> bool:
+            return not isValid(obj)
+
+    except ImportError as e:
+        raise Exception("Could not delegate is_qt_object_destroyed check") from e
+
 
 # QObject and EventFilter(ABC) use incompatible metaclasses. This combined metaclass
 # inherits from both so that QtEventFilter can subclass QObject and EventFilter,
@@ -72,12 +88,14 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
         self._widget = widget
         self._handler = handler
         self._active_buttons: MouseButton = MouseButton.NONE
-        widget.destroyed.connect(self.uninstall)
 
     def eventFilter(self, a0: QObject | None = None, a1: QEvent | None = None) -> bool:
-        if isinstance(a0, QWidget) and not a0.signalsBlocked():
-            if isinstance(a1, QEvent) and (evt := self._convert_event(a1)):
-                return self._handler(evt)
+        if a0 is not self._widget:
+            return False
+        if self._widget.signalsBlocked() or is_qt_object_destroyed(self._widget):
+            return False
+        if isinstance(a1, QEvent) and (evt := self._convert_event(a1)):
+            return self._handler(evt)
         return False
 
     def uninstall(self) -> None:

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -74,21 +74,13 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
         self._active_buttons: MouseButton = MouseButton.NONE
 
     def eventFilter(self, a0: QObject | None = None, a1: QEvent | None = None) -> bool:
-        if a0 is not self._widget:
-            return False
-        if self._widget.signalsBlocked():
-            return False
-        if isinstance(a1, QEvent) and (evt := self._convert_event(a1)):
-            return self._handler(evt)
+        if isinstance(a0, QWidget) and not a0.signalsBlocked():
+            if isinstance(a1, QEvent) and (evt := self._convert_event(a1)):
+                return self._handler(evt)
         return False
 
     def uninstall(self) -> None:
-        try:
-            self._widget.removeEventFilter(self)
-        except RuntimeError:
-            # This can happen if the widget has already been deleted.
-            # In that case, we can just ignore it.
-            pass
+        self._widget.removeEventFilter(self)
 
     def mouse_btn(self, btn: Any) -> MouseButton:
         if btn == Qt.MouseButton.LeftButton:

--- a/src/scenex/app/_qt.py
+++ b/src/scenex/app/_qt.py
@@ -74,12 +74,19 @@ class QtEventFilter(QObject, EventFilter, metaclass=_QtEventFilterMeta):
         self._active_buttons: MouseButton = MouseButton.NONE
 
     def eventFilter(self, a0: QObject | None = None, a1: QEvent | None = None) -> bool:
-        if not isinstance(a0, QWidget) or not isinstance(a1, QEvent):
+        # Ensure a real event on a real widget
+        if a0 is None or a1 is None:
             return False
+        # If the widget is being closed, uninstall the event filter
         if a1.type() == QEvent.Type.Close:
             self.uninstall()
             return False
-        if not a0.signalsBlocked() and (evt := self._convert_event(a1)):
+        # Ignore events if they are being blocked
+        if a0.signalsBlocked():
+            return False
+        # If we can convert the event...
+        if evt := self._convert_event(a1):
+            # ...handle it!
             return self._handler(evt)
         return False
 

--- a/tests/app/test_qt.py
+++ b/tests/app/test_qt.py
@@ -52,9 +52,8 @@ def evented_canvas(qtbot: QtBot) -> Iterator[snx.Canvas]:
     canvas = snx.Canvas(views=[view])
     adaptor = cast("CanvasAdaptor", canvas._get_adaptors(create=True)[0])
     native = adaptor._snx_get_native()
-    qtbot.addWidget(native)
+    qtbot.addWidget(native, before_close_func=lambda _: adaptor._filter.uninstall())  # type: ignore
     yield canvas
-    adaptor._filter.uninstall()  # type: ignore
 
 
 @pytest.mark.parametrize(

--- a/tests/app/test_qt.py
+++ b/tests/app/test_qt.py
@@ -25,6 +25,8 @@ from scenex.app.events import (
 from scenex.model._transform import Transform
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from scenex.adaptors._base import CanvasAdaptor
 
 if determine_app() == GuiFrontend.QT:
@@ -43,16 +45,16 @@ else:
 
 
 @pytest.fixture
-def evented_canvas(qtbot: QtBot) -> snx.Canvas:
+def evented_canvas(qtbot: QtBot) -> Iterator[snx.Canvas]:
     camera = snx.Camera(transform=Transform(), interactive=True)
     scene = snx.Scene(children=[])
     view = snx.View(scene=scene, camera=camera)
     canvas = snx.Canvas(views=[view])
-    native = cast(
-        "CanvasAdaptor", canvas._get_adaptors(create=True)[0]
-    )._snx_get_native()
+    adaptor = cast("CanvasAdaptor", canvas._get_adaptors(create=True)[0])
+    native = adaptor._snx_get_native()
     qtbot.addWidget(native)
-    return canvas
+    yield canvas
+    adaptor._filter.uninstall()  # type: ignore
 
 
 @pytest.mark.parametrize(
@@ -144,10 +146,7 @@ def test_mouse_double_click(evented_canvas: snx.Canvas, qtbot: QtBot) -> None:
 
 
 def test_resize(evented_canvas: snx.Canvas, qtbot: QtBot) -> None:
-    native = cast(
-        "CanvasAdaptor", evented_canvas._get_adaptors(create=True)[0]
-    )._snx_get_native()
-    qtbot.add_widget(native)
+    native = cast("CanvasAdaptor", evented_canvas._get_adaptors()[0])._snx_get_native()
     new_size = (400, 300)
     assert evented_canvas.width != new_size[0]
     assert evented_canvas.height != new_size[1]

--- a/tests/app/test_qt.py
+++ b/tests/app/test_qt.py
@@ -25,8 +25,6 @@ from scenex.app.events import (
 from scenex.model._transform import Transform
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from scenex.adaptors._base import CanvasAdaptor
 
 if determine_app() == GuiFrontend.QT:
@@ -45,7 +43,7 @@ else:
 
 
 @pytest.fixture
-def evented_canvas(qtbot: QtBot) -> Iterator[snx.Canvas]:
+def evented_canvas(qtbot: QtBot) -> snx.Canvas:
     camera = snx.Camera(transform=Transform(), interactive=True)
     scene = snx.Scene(children=[])
     view = snx.View(scene=scene, camera=camera)
@@ -53,7 +51,7 @@ def evented_canvas(qtbot: QtBot) -> Iterator[snx.Canvas]:
     adaptor = cast("CanvasAdaptor", canvas._get_adaptors(create=True)[0])
     native = adaptor._snx_get_native()
     qtbot.addWidget(native, before_close_func=lambda _: adaptor._filter.uninstall())  # type: ignore
-    yield canvas
+    return canvas
 
 
 @pytest.mark.parametrize(

--- a/tests/app/test_qt.py
+++ b/tests/app/test_qt.py
@@ -48,9 +48,10 @@ def evented_canvas(qtbot: QtBot) -> snx.Canvas:
     scene = snx.Scene(children=[])
     view = snx.View(scene=scene, camera=camera)
     canvas = snx.Canvas(views=[view])
-    adaptor = cast("CanvasAdaptor", canvas._get_adaptors(create=True)[0])
-    native = adaptor._snx_get_native()
-    qtbot.addWidget(native, before_close_func=lambda _: adaptor._filter.uninstall())  # type: ignore
+    native = cast(
+        "CanvasAdaptor", canvas._get_adaptors(create=True)[0]
+    )._snx_get_native()
+    qtbot.addWidget(native)
     return canvas
 
 


### PR DESCRIPTION
We occasionally get segfaults on CI from the pyqt backend, looking like this:

```
Windows fatal exception: access violation

Current thread 0x000005cc (most recent call first):
  File "D:\a\scenex\scenex\src\scenex\app\_qt.py", line 100 in _convert_event
  File "D:\a\scenex\scenex\src\scenex\app\_qt.py", line 78 in eventFilter
  File "D:\a\scenex\scenex\.venv\lib\site-packages\vispy\app\backends\_qt.py", line 692 in event
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pytestqt\qtbot.py", line 808 in _close_widgets
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pytestqt\plugin.py", line 203 in pytest_runtest_teardown
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_callers.py", line 116 in _multicall
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\runner.py", line 245 in <lambda>
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\runner.py", line 353 in from_call
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\runner.py", line 244 in call_and_report
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\runner.py", line 142 in runtestprotocol
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\runner.py", line 118 in pytest_runtest_protocol
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\main.py", line 396 in pytest_runtestloop
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\main.py", line 372 in _main
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\main.py", line 318 in wrap_session
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\main.py", line 365 in pytest_cmdline_main
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_callers.py", line 121 in _multicall
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_manager.py", line 120 in _hookexec
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pluggy\_hooks.py", line 512 in __call__
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\config\__init__.py", line 199 in main
  File "D:\a\scenex\scenex\.venv\lib\site-packages\_pytest\config\__init__.py", line 223 in console_main
  File "D:\a\scenex\scenex\.venv\lib\site-packages\pytest\__main__.py", line 9 in <module>
  File "D:\a\scenex\scenex\.venv\lib\site-packages\coverage\execfile.py", line 213 in run
  File "D:\a\scenex\scenex\.venv\lib\site-packages\coverage\cmdline.py", line 1043 in do_run
  File "D:\a\scenex\scenex\.venv\lib\site-packages\coverage\cmdline.py", line 853 in command_line
  File "D:\a\scenex\scenex\.venv\lib\site-packages\coverage\cmdline.py", line 1164 in main
  File "D:\a\scenex\scenex\.venv\Scripts\coverage.exe\__main__.py", line 10 in <module>
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\runpy.py", line 86 in _run_code
  File "C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\runpy.py", line 196 in _run_module_as_main
D:\a\_temp\ddd942f7-1e87-4e38-818f-6c9d88eaa2d8.sh: line 1:  1770 Segmentation fault         uv run --no-sync coverage run -p -m pytest -v
```

This branch aims to fix those. Of course, this will be tricky due to the sporadic nature...