### PR TITLE
Always autogenerate the examples

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -28,7 +28,6 @@ jobs:
           git fetch origin gh-pages --depth=1
 
       - name: Autogenerate examples
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
           uv run --exact --no-dev --extra pygfx --extra pyqt6 --group docs python docs/gen_examples.py
 


### PR DESCRIPTION
This PR removes a line that only autogenerated the scenex example docs pages when we did a release build of the docs.